### PR TITLE
support for alpha on colorFilters on iOS

### DIFF
--- a/src/ios/LottieReactNative/ContainerView.swift
+++ b/src/ios/LottieReactNative/ContainerView.swift
@@ -94,21 +94,22 @@ class ContainerView: RCTView {
         }
 
         if ((cString.count) == 0) {
-            return UIColor.red
+            return UIColor.white
         }
 
-        if ((cString.count) != 6) {
-            return UIColor.green
+        if ((cString.count) == 6) {
+            cString  = cString + "FF"
         }
 
-        var rgbValue:UInt32 = 0
-        Scanner(string: cString).scanHexInt32(&rgbValue)
+        var rgbValue:UInt64 = 0
+        Scanner(string: cString).scanHexInt64(&rgbValue)
 
         return UIColor(
-            red: CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
-            green: CGFloat((rgbValue & 0x00FF00) >> 8) / 255.0,
-            blue: CGFloat(rgbValue & 0x0000FF) / 255.0,
-            alpha: CGFloat(1.0)
+            red: CGFloat((rgbValue & 0xFF000000) >> 24) / 255.0,
+            green: CGFloat((rgbValue & 0x00FF0000) >> 16) / 255.0,
+            blue: CGFloat((rgbValue & 0x0000FF00) >> 8) / 255.0,
+            alpha: CGFloat(rgbValue & 0x000000FF) / 255.0
+            
         )
     }
 


### PR DESCRIPTION
# Summary
support for alpha on colorFilters on iOS

```javascript
<LottieView
        source={require('./animation.json')}
        colorFilters={[
          {
            keypath: 'layer1',
            color: '#FF0000BB',
          },
        ]}
      />

```

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
