### PR TITLE
Updated resizeMode to use FIT_CENTER instead of CENTER_INSIDE.

### DIFF
--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
@@ -49,7 +49,7 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
 
   @Override public LottieAnimationView createViewInstance(ThemedReactContext context) {
     final LottieAnimationView view = new LottieAnimationView(context);
-    view.setScaleType(ImageView.ScaleType.CENTER_INSIDE);
+    view.setScaleType(ImageView.ScaleType.FIT_CENTER);
     view.addAnimatorListener(new Animator.AnimatorListener() {
       @Override
       public void onAnimationStart(Animator animation) {}
@@ -208,7 +208,7 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
     if ("cover".equals(resizeMode)) {
       mode = ImageView.ScaleType.CENTER_CROP;
     } else if ("contain".equals(resizeMode)) {
-      mode = ImageView.ScaleType.CENTER_INSIDE;
+      mode = ImageView.ScaleType.FIT_CENTER;
     } else if ("center".equals(resizeMode)) {
       mode = ImageView.ScaleType.CENTER;
     }


### PR DESCRIPTION
When using `resizeMode="contain"` on Android the lottie image does not grow to fill the container. If the actually dimensions of the lottie are 100x100 and the container is 50x50 then `resizeMode="contain"`will make the lottie shrink to 50x50 but if the container is 200x200 the lottie does not grow past 100x100.

Changing `ImageView.ScaleType.CENTER_INSIDE` to `ImageView.ScaleType.FIT_CENTER` resolves this issue.