### PR TITLE
RCT_DEV replaced with RCT_DEBUG

### DIFF
--- a/src/ios/LottieReactNative/AnimationViewManagerModule.swift
+++ b/src/ios/LottieReactNative/AnimationViewManagerModule.swift
@@ -20,7 +20,7 @@ class AnimationViewManagerModule: RCTViewManager {
         
         self.bridge.uiManager.addUIBlock { (uiManager, viewRegistry) in
             guard let view = viewRegistry?[reactTag] as? ContainerView else {
-                if (RCT_DEV == 1) {
+                if (RCT_DEBUG == 1) {
                     print("Invalid view returned from registry, expecting ContainerView")
                 }
                 return
@@ -44,7 +44,7 @@ class AnimationViewManagerModule: RCTViewManager {
     public func reset(_ reactTag: NSNumber) {
         self.bridge.uiManager.addUIBlock { uiManager, viewRegistry in
             guard let view = viewRegistry?[reactTag] as? ContainerView else {
-                if (RCT_DEV == 1) {
+                if (RCT_DEBUG == 1) {
                     print("Invalid view returned from registry, expecting ContainerView")
                 }
                 return
@@ -58,7 +58,7 @@ class AnimationViewManagerModule: RCTViewManager {
     public func pause(_ reactTag: NSNumber) {
         self.bridge.uiManager.addUIBlock { uiManager, viewRegistry in
             guard let view = viewRegistry?[reactTag] as? ContainerView else {
-                if (RCT_DEV == 1) {
+                if (RCT_DEBUG == 1) {
                     print("Invalid view returned from registry, expecting ContainerView")
                 }
                 return
@@ -72,7 +72,7 @@ class AnimationViewManagerModule: RCTViewManager {
     public func resume(_ reactTag: NSNumber) {
         self.bridge.uiManager.addUIBlock { uiManager, viewRegistry in
             guard let view = viewRegistry?[reactTag] as? ContainerView else {
-                if (RCT_DEV == 1) {
+                if (RCT_DEBUG == 1) {
                     print("Invalid view returned from registry, expecting ContainerView")
                 }
                 return

--- a/src/ios/LottieReactNative/ContainerView.swift
+++ b/src/ios/LottieReactNative/ContainerView.swift
@@ -48,7 +48,7 @@ class ContainerView: RCTView {
 
         guard let data = sourceJson.data(using: String.Encoding.utf8),
         let animation = try? JSONDecoder().decode(Animation.self, from: data) else {
-            if (RCT_DEV == 1) {
+            if (RCT_DEBUG == 1) {
                 print("Unable to create the lottie animation object from the JSON source")
             }
             return


### PR DESCRIPTION
RCT_DEV can be used to enable or disable development tools but RCT_DEBUG can be used to exclude error checking and logging code from release builds. (https://github.com/facebook/react-native/blob/master/React/Base/RCTDefines.h)
RCT_DEV replaced with RCT_DEBUG to disable logging.

