### PR TITLE
Fix Android playback when startFrame > endFrame

### DIFF
--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
@@ -118,11 +118,16 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
             int startFrame = args.getInt(0);
             int endFrame = args.getInt(1);
             if (startFrame != -1 && endFrame != -1) {
-               if(startFrame > endFrame){
+               if (startFrame > endFrame) {
                 view.setMinAndMaxFrame(endFrame, startFrame);
-                view.reverseAnimationSpeed();
+                if (view.getSpeed() > 0) {
+                  view.reverseAnimationSpeed();
+                }
               } else {
                 view.setMinAndMaxFrame(startFrame, endFrame);
+                if (view.getSpeed() < 0) {
+                  view.reverseAnimationSpeed();
+                }
               }
             }
             if (ViewCompat.isAttachedToWindow(view)) {


### PR DESCRIPTION
Everytime we played an animation with startFrame > endFrame, we
were reversing the animation speed. As so, it played correctly
for the first time, but incorrectly on the second (as it was
reversed back to the regular animation speed).

Now, we only reverse the animation speed if needed. Additionally
we restore the original animation speed if needed for
startFrame < endFrame.