### PR TITLE
fix: move `lottie-ios` to `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,11 +43,11 @@
   "homepage": "https://github.com/airbnb/lottie-react-native#readme",
   "peerDependencies": {
     "react": "*",
-    "react-native": ">=0.46"
+    "react-native": ">=0.46",
+    "lottie-ios": "^3.1.8"
   },
   "dependencies": {
     "invariant": "^2.2.2",
-    "lottie-ios": "^3.1.8",
     "prop-types": "^15.5.10",
     "react-native-safe-modules": "^1.0.0"
   },


### PR DESCRIPTION
`lottie-ios` is a project with native code and it has to be linked.

react-native autolinking can only work as long as project is listed in
the output of `react-native config` which considers `package.json` in
order to build list of dependencies which need to be linked.

currently having `lottie-ios` in `dependencies` does not make lots of
sense since in order to successfully install and use
`lottie-react-native` one has to install `lottie-ios` separately and
make sure it's listed in `package.json`.

in fact it may lead to situatoin when two copies of `lottie-ios` may be
installed in case if range of `lottie-ios` inside package.json of
`lottie-react-native` and inside actual package of the app are
conflicting.