### PR TITLE
Fix react-native 0.64 compatibility

### DIFF
--- a/lottie-react-native.podspec
+++ b/lottie-react-native.podspec
@@ -15,8 +15,11 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/react-community/lottie-react-native.git", :tag => "v#{s.version}" }
   s.source_files  = "src/ios/**/*.{h,m,swift}"
-  s.swift_version = "5.0"
+
   s.requires_arc = true
+
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+
   s.dependency 'React-Core'
   s.dependency 'lottie-ios', '~> 3.1.8'
 end

--- a/lottie-react-native.podspec
+++ b/lottie-react-native.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/react-community/lottie-react-native.git", :tag => "v#{s.version}" }
   s.source_files  = "src/ios/**/*.{h,m,swift}"
   s.swift_version = "5.0"
-  s.dependency 'React'
   s.requires_arc = true
+  s.dependency 'React-Core'
   s.dependency 'lottie-ios', '~> 3.1.8'
 end

--- a/lottie-react-native.podspec
+++ b/lottie-react-native.podspec
@@ -17,5 +17,6 @@ Pod::Spec.new do |s|
   s.source_files  = "src/ios/**/*.{h,m,swift}"
   s.swift_version = "5.0"
   s.dependency 'React'
+  s.requires_arc = true
   s.dependency 'lottie-ios', '~> 3.1.8'
 end

--- a/src/ios/LottieReactNative/AnimationViewManagerModule.swift
+++ b/src/ios/LottieReactNative/AnimationViewManagerModule.swift
@@ -1,7 +1,3 @@
-#if canImport(React)
-import React
-#endif
-
 import Lottie
 
 #if os(OSX)

--- a/src/ios/LottieReactNative/ContainerView.swift
+++ b/src/ios/LottieReactNative/ContainerView.swift
@@ -1,7 +1,3 @@
-#if canImport(React)
-import React
-#endif
-
 import Lottie
 
 class ContainerView: RCTView {
@@ -17,7 +13,7 @@ class ContainerView: RCTView {
 
     @objc func setSpeed(_ newSpeed: CGFloat) {
         speed = newSpeed
-        
+
         if (newSpeed != 0.0) {
             animationView?.animationSpeed = newSpeed
             if (!(animationView?.isAnimationPlaying ?? true)) {
@@ -100,7 +96,7 @@ class ContainerView: RCTView {
         animationView?.currentProgress = 0;
         animationView?.pause()
     }
-    
+
     func pause() {
         animationView?.pause()
     }


### PR DESCRIPTION
* Enables ARC (automatic reference counting)
* Depends on React-Core (fixes Xcode 12 compatibility)
* Removes unnecessary React imports in swift code
* Sets `DEFINES_MODULE` to true (creates header maps, allows React-Core interop)
* Removes `SWIFT_VERSION` pinning