### PR TITLE
Added boolean flag cacheComposition for Android

### DIFF
--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
@@ -207,6 +207,11 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
     getOrCreatePropertyManager(view).setAnimationJson(json);
   }
 
+  @ReactProp(name = "cacheComposition")
+  public void setCacheComposition(LottieAnimationView view, boolean cacheComposition) {
+    view.setCacheComposition(cacheComposition);
+  }
+
   @ReactProp(name = "resizeMode")
   public void setResizeMode(LottieAnimationView view, String resizeMode) {
     ImageView.ScaleType mode = null;

--- a/src/js/LottieView.js
+++ b/src/js/LottieView.js
@@ -15,7 +15,7 @@ import PropTypes from 'prop-types';
 
 
 const getNativeLottieViewForMac = () => {
-  return requireNativeComponent('LottieAnimationView') 
+  return requireNativeComponent('LottieAnimationView')
 }
 
 const NativeLottieView =
@@ -76,6 +76,7 @@ const propTypes = {
   source: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
   onAnimationFinish: PropTypes.func,
   onLayout: PropTypes.func,
+  cacheComposition: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -85,6 +86,7 @@ const defaultProps = {
   autoPlay: false,
   autoSize: false,
   enableMergePathsAndroidForKitKatAndAbove: false,
+  cacheComposition: true,
   resizeMode: 'contain',
 };
 
@@ -132,7 +134,7 @@ class LottieView extends React.PureComponent {
   reset() {
     this.runCommand('reset');
   }
-  
+
   pause() {
     this.runCommand('pause');
   }
@@ -175,7 +177,7 @@ class LottieView extends React.PureComponent {
       this.props.onAnimationFinish(evt.nativeEvent.isCancelled);
     }
   }
-  
+
   onLayout(evt) {
     if (this.props.onLayout) {
       this.props.onLayout(evt);

--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -95,6 +95,12 @@ declare module "lottie-react-native" {
     renderMode?: "AUTOMATIC" | "HARDWARE" | "SOFTWARE";
 
     /**
+     * [Android]. A boolean flag indicating whether or not the animation should caching. Defaults to true.
+     * Refer to LottieAnimationView#setCacheComposition(boolean) for more information.
+     */
+    cacheComposition?: boolean;
+
+    /**
      * [Android]. Allows to specify kind of cache used for animation. Default value weak.
      * strong - cached forever
      * weak   - cached as long it is in active use


### PR DESCRIPTION
A boolean flag indicating whether or not the animation should caching. Defaults to true. Refer to LottieAnimationView#setCacheComposition(boolean) for more information.

Addresses and closes issues #746  and #745 .