### PR TITLE
Swift Version on Pod spec

### DIFF
--- a/lottie-react-native.podspec
+++ b/lottie-react-native.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
-
+  s.swift_version = "5.0"
   s.dependency 'React-Core'
   s.dependency 'lottie-ios', '~> 3.1.8'
 end


### PR DESCRIPTION
Fixes this error during RN macOS init:

[!] Unable to determine Swift version for the following pods:  - `lottie-react-native-macOS` does not specify a Swift version and none of the targets (`bluewallet-macOS`) integrating it have the `SWIFT_VERSION` attribute set. Please contact the author or set the `SWIFT_VERSION` attribute in at least one of the targets that integrate this pod.