### PR TITLE
remove buildToolsVersion

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -9,7 +9,6 @@ apply from: 'gradle-maven-push.gradle'
 
 android {
   compileSdkVersion safeExtGet('compileSdkVersion', 28)
-  buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
 
   defaultConfig {
     minSdkVersion safeExtGet('minSdkVersion', 16)
@@ -27,9 +26,6 @@ android {
 }
 
 dependencies {
-  //def supportLibVersion = safeExtGet('supportLibVersion', DEFAULT_ANDROID_SUPPORT_LIB_VERSION)
-
   implementation "com.facebook.react:react-native:+"
-  implementation "androidx.appcompat:appcompat:1.0.0"
   implementation 'com.airbnb.android:lottie:3.4.0'
 }


### PR DESCRIPTION
Setting buildToolsVersion is no longer recommended, it'll default to Android Gradle Plugin defaults. It makes DX worse by requiring multiple versions of build tools by various dependencies require various versions.

Also appcompat will come with react-native