### PR TITLE
Build on xcode 13 beta

### DIFF
--- a/lottie-react-native.podspec
+++ b/lottie-react-native.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.authors      = { "intelligibabble" => "leland.m.richardson@gmail.com" }
   s.homepage     = "https://github.com/airbnb/lottie-react-native#readme"
   s.license      = package['license']
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '12.0'
   s.osx.deployment_target = '10.10'
 
   s.source       = { :git => "https://github.com/react-community/lottie-react-native.git", :tag => "v#{s.version}" }


### PR DESCRIPTION
Regarding: https://github.com/onevcat/Kingfisher/issues/1725

"This seems only happens for SPM and it requires a minimum target iOS 12 to build successfully. I don't think this is reasonable and it is definitely an issue of the build system (unless Apple officially confirms they want to drop any deploy target below iOS 12)"