### PR TITLE
Fix `onAnimationFinish` callback behavior after resuming on iOS

### DIFF
--- a/src/ios/LottieReactNative/AnimationViewManagerModule.swift
+++ b/src/ios/LottieReactNative/AnimationViewManagerModule.swift
@@ -22,7 +22,6 @@ class AnimationViewManagerModule: RCTViewManager {
         return ["VERSION": 1]
     }
 
-
     @objc(play:fromFrame:toFrame:)
     public func play(_ reactTag: NSNumber, startFrame: NSNumber, endFrame: NSNumber) {
         self.bridge.uiManager.addUIBlock { (uiManager, viewRegistry) in
@@ -33,16 +32,10 @@ class AnimationViewManagerModule: RCTViewManager {
                 return
             }
 
-            let callback: LottieCompletionBlock = { animationFinished in
-                if let onFinish = view.onAnimationFinish {
-                    onFinish(["isCancelled": !animationFinished])
-                }
-            }
-
             if (startFrame.intValue != -1 && endFrame.intValue != -1) {
-                view.play(fromFrame: AnimationFrameTime(truncating: startFrame), toFrame: AnimationFrameTime(truncating: endFrame), completion: callback)
+                view.play(fromFrame: AnimationFrameTime(truncating: startFrame), toFrame: AnimationFrameTime(truncating: endFrame))
             } else {
-                view.play(completion: callback)
+                view.play()
             }
         }
     }

--- a/src/ios/LottieReactNative/ContainerView.swift
+++ b/src/ios/LottieReactNative/ContainerView.swift
@@ -84,7 +84,7 @@ class ContainerView: RCTView {
 
     func play(fromFrame: AnimationFrameTime? = nil, toFrame: AnimationFrameTime) {
         let callback: LottieCompletionBlock = { animationFinished in
-            if let onFinish = view.onAnimationFinish {
+            if let onFinish = self.onAnimationFinish {
                 onFinish(["isCancelled": !animationFinished])
             }
         }
@@ -95,7 +95,7 @@ class ContainerView: RCTView {
 
     func play() {
         let callback: LottieCompletionBlock = { animationFinished in
-            if let onFinish = view.onAnimationFinish {
+            if let onFinish = self.onAnimationFinish {
                 onFinish(["isCancelled": !animationFinished])
             }
         }

--- a/src/ios/LottieReactNative/ContainerView.swift
+++ b/src/ios/LottieReactNative/ContainerView.swift
@@ -82,14 +82,26 @@ class ContainerView: RCTView {
         applyProperties()
     }
 
-    func play(fromFrame: AnimationFrameTime? = nil, toFrame: AnimationFrameTime, completion: LottieCompletionBlock? = nil) {
+    func play(fromFrame: AnimationFrameTime? = nil, toFrame: AnimationFrameTime) {
+        let callback: LottieCompletionBlock = { animationFinished in
+            if let onFinish = view.onAnimationFinish {
+                onFinish(["isCancelled": !animationFinished])
+            }
+        }
+
         animationView?.backgroundBehavior = .pauseAndRestore
-        animationView?.play(fromFrame: fromFrame, toFrame: toFrame, loopMode: self.loop, completion: completion);
+        animationView?.play(fromFrame: fromFrame, toFrame: toFrame, loopMode: self.loop, completion: callback);
     }
 
-    func play(completion: LottieCompletionBlock? = nil) {
+    func play() {
+        let callback: LottieCompletionBlock = { animationFinished in
+            if let onFinish = view.onAnimationFinish {
+                onFinish(["isCancelled": !animationFinished])
+            }
+        }
+
         animationView?.backgroundBehavior = .pauseAndRestore
-        animationView?.play(completion: completion)
+        animationView?.play(completion: callback)
     }
 
     func reset() {


### PR DESCRIPTION
This PR fixes an issue that causes erratic `onAnimationFinish` callbacks on iOS when we call `resume()`. Since the callback was passed in with the call to `play(..., completion: handler)`, and since `resume()` calls `play()` without any arguments, the animation completion callback gets lost if we ever pause the animation. (Note: that's not what's done in the android version), 

Here, we remove callback the references from the iOS manager module. Since `ContainerView` holds the property, we can always pass the callback directly in there.