### PR TITLE
Upgrading Native lottie Android to 4.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.5.2'
+    classpath 'com.android.tools.build:gradle:3.5.4'
   }
 }
 

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -27,5 +27,5 @@ android {
 
 dependencies {
   implementation "com.facebook.react:react-native:+"
-  implementation 'com.airbnb.android:lottie:3.4.0'
+  implementation 'com.airbnb.android:lottie:4.0.0'
 }


### PR DESCRIPTION
Upgraded as a first step to migrating to gradle 7. It simply points to the latest native Android version: https://github.com/airbnb/lottie-android/releases/tag/v4.0.0