### PR TITLE
migrated to maven_publish

### DIFF
--- a/src/android/gradle-maven-push.gradle
+++ b/src/android/gradle-maven-push.gradle
@@ -73,6 +73,11 @@ afterEvaluate { project ->
               name = POM_DEVELOPER_NAME
             }
           }
+          scm {
+            connection = 'scm:git:git://github.com/lottie-react-native/lottie-react-native.git'
+            developerConnection = 'scm:git:ssh://github.com/lottie-react-native/lottie-react-native.git'
+            url = 'https://github.com/lottie-react-native/lottie-react-native'
+          }
         }
       }
     }

--- a/src/android/gradle-maven-push.gradle
+++ b/src/android/gradle-maven-push.gradle
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 def isReleaseBuild() {
@@ -40,56 +40,58 @@ def getRepositoryPassword() {
 }
 
 afterEvaluate { project ->
-  uploadArchives {
-    repositories {
-      mavenDeployer {
-        beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+  publishing {
+    publications {
+      mavenJava(MavenPublication) {
+        groupId = GROUP
+        artifactId = POM_ARTIFACT_ID
+        version = VERSION_NAME
 
-        pom.groupId = GROUP
-        pom.artifactId = POM_ARTIFACT_ID
-        pom.version = VERSION_NAME
-
-        repository(url: getReleaseRepositoryUrl()) {
-          authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-        }
-        snapshotRepository(url: getSnapshotRepositoryUrl()) {
-          authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-        }
-
-        pom.project {
-          name POM_NAME
-          packaging POM_PACKAGING
-          description POM_DESCRIPTION
-          url POM_URL
+        pom {
+          name = POM_NAME
+          packaging = POM_PACKAGING
+          description = POM_DESCRIPTION
+          url = POM_URL
 
           scm {
-            url POM_SCM_URL
-            connection POM_SCM_CONNECTION
-            developerConnection POM_SCM_DEV_CONNECTION
+            url = POM_SCM_URL
+            connection = POM_SCM_CONNECTION
+            developerConnection = POM_SCM_DEV_CONNECTION
           }
 
           licenses {
             license {
-              name POM_LICENSE_NAME
-              url POM_LICENSE_URL
-              distribution POM_LICENSE_DIST
+              name = POM_LICENSE_NAME
+              url = POM_LICENSE_URL
+              distribution = POM_LICENSE_DIST
             }
           }
 
           developers {
             developer {
-              id POM_DEVELOPER_ID
-              name POM_DEVELOPER_NAME
+              id = POM_DEVELOPER_ID
+              name = POM_DEVELOPER_NAME
             }
           }
         }
       }
     }
+    repositories {
+      maven {
+        url = isReleaseBuild() ? getReleaseRepositoryUrl() : getSnapshotRepositoryUrl()
+
+        credentials {
+          username = getRepositoryUsername()
+          password = getRepositoryPassword()
+        }
+      }
+    }
   }
+
 
   signing {
     required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
-    sign configurations.archives
+    sign publishing.publications.mavenJava
   }
 
   task androidJavadocs(type: Javadoc) {


### PR DESCRIPTION
the `maven` gradle plugin has been deprecated for a while. The replacement is `maven-plugin` that has some changes to the DSL. I have adapted them. I have verified that compilation works but for obvious reasons, I can't publish it myself. 

This migration is necessary in order to move `lottie-react-native-` to use gradle 7.0.0+ used in the latest Android Studio.
This is a dependency to https://github.com/lottie-react-native/lottie-react-native/pull/799 but the change can be merged independently