### PR TITLE
Play from start to end if no argument is passed on Android

### DIFF
--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java
@@ -129,6 +129,8 @@ class LottieAnimationViewManager extends SimpleViewManager<LottieAnimationView> 
                   view.reverseAnimationSpeed();
                 }
               }
+            } else {
+              view.setMinAndMaxFrame(Integer.MIN_VALUE, Integer.MAX_VALUE);
             }
             if (ViewCompat.isAttachedToWindow(view)) {
               view.setProgress(0f);


### PR DESCRIPTION
Currently on Android only, if no argument is passed to `play()` function, it uses the previous `start` and `end` frames.

```tsx
const ref = useRef();
if (count % 2 === 0) {
  ref.current?.play();
} else {
  ref.current?.play(1, 0);
}
count++;
```

Thus, the code above runs normally only for the first time, and from the second time, it always plays from 1 to 0.
This behavior does not align with the one in iOS and seems not expected. Reseting these values to the default if not specified is probably more natural and expected.