### PR TITLE
Fix incompatible types of objects

### DIFF
--- a/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.java
+++ b/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.java
@@ -161,7 +161,7 @@ public class LottieAnimationViewPropertyManager {
           color = current.getInt("color");
         }
         String path = current.getString("keypath");
-        SimpleColorFilter colorFilter = new SimpleColorFilter(color);
+        ColorFilter colorFilter = new SimpleColorFilter(color);
         String pathWithGlobstar = path +".**";
         String[] keys = pathWithGlobstar.split(Pattern.quote("."));
         KeyPath keyPath = new  KeyPath(keys);


### PR DESCRIPTION
<h3>This pull request fix a error.</h3>
<hr />

### Explanation
* Changing the object type as it is causing android app installation errors.

### How to reproduce
* Install react latest versions: react 17.0.2, react-native 0.66.3;
* Install lottie-react-native@latest version and it peerDependencies lottie-ios@3.2.3;
* Run ```npx react-native run-android```;
* The error described at #820 will be displayed.