### PR TITLE
Fix UITraitCollection.hasDifferentColorAppearance check for tvOS version less than 13.0

### DIFF
--- a/src/ios/LottieReactNative/ContainerView.swift
+++ b/src/ios/LottieReactNative/ContainerView.swift
@@ -14,7 +14,7 @@ class ContainerView: RCTView {
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        if #available(iOS 13.0, *) {
+        if #available(iOS 13.0, tvOS 13.0, *) {
             if (self.traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
                 applyProperties()
                 print("dark mode changed")


### PR DESCRIPTION
I got the following build error on tvOS after upgrade lottie-react-native to v5:

```
'hasDifferentColorAppearance(comparedTo:)' is only available in tvOS 13.0 or newer
```

This simple fix just add '#available' version check for tvOS.

