### PR TITLE
docs: add `resizeMode` to Component API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -9,6 +9,7 @@
 |**`loop`**|A boolean flag indicating whether or not the animation should loop. |`true`|
 |**`autoPlay`**|A boolean flag indicating whether or not the animation should start automatically when mounted. This only affects the imperative API.  |`false`|
 |**`autoSize`**|A boolean flag indicating whether or not the animation should size itself automatically according to the width in the animation's JSON. This only works when `source` is an actual JS object of an animation.  |`false`|
+|**`resizeMode`**|Determines how to resize the animated view when the frame doesn't match the raw image dimensions. Supports `cover`, `contain` and `center`.  |`contain`|
 |**`style`**|Style attributes for the view, as expected in a standard [`View`](http://facebook.github.io/react-native/releases/0.46/docs/layout-props.html), aside from border styling |*None*|
 |**`imageAssetsFolder`**| Needed for **Android** to work properly with assets, iOS will ignore it. |*None*|
 |**`onAnimationFinish`**| A callback function which will be called when animation is finished. This callback is called with a boolean `isCancelled` argument, indicating if the animation actually completed playing, or if it was cancelled, for instance by calling `play()` or `reset()` while is was still playing. Note that this callback will be called only when `loop` is set to false. |*None*|


### PR DESCRIPTION
This PR adds the [`resizeMode`](https://github.com/lottie-react-native/lottie-react-native/blob/master/src/js/LottieView.js#L69) prop to the "Component API" docs.