### PR TITLE
fix: tvOS <13.0 build issue

### DIFF
--- a/src/ios/LottieReactNative/ContainerView.swift
+++ b/src/ios/LottieReactNative/ContainerView.swift
@@ -16,9 +16,13 @@ class ContainerView: RCTView {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if #available(iOS 13.0, *) {
-            if (self.traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
-                applyProperties()
-                print("dark mode changed")
+            if #available(tvOS 13.0, *) {
+                if (self.traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
+                    applyProperties()
+                    print("dark mode changed")
+                }
+            } else {
+                // Fallback on earlier versions
             }
         }
     }


### PR DESCRIPTION
This PR fixes build issues on tvOS <13.0.

The error was 
`‘hasDifferentColorAppearance(comparedTo:)’ is only available in tvOS 13.0 or newer`
caused by a missing `#available` guard condition for tvOS.