### PR TITLE
Remove PropTypes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
     "react/jsx-filename-extension": 0,
     "react/sort-comp": 0,
     "react/require-extension": 0,
+    "react/prop-types": 0,
     "import/no-extraneous-dependencies": 0,
     "import/no-unresolved": [2, { "ignore": ["^lottie-react-native$"] }],
     "no-console": 0,

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   },
   "dependencies": {
     "invariant": "^2.2.2",
-    "prop-types": "^15.5.10",
     "react-native-safe-modules": "^1.0.3"
   },
   "devDependencies": {

--- a/src/js/LottieView.js
+++ b/src/js/LottieView.js
@@ -6,13 +6,11 @@ import {
   View,
   Platform,
   StyleSheet,
-  ViewPropTypes,
   requireNativeComponent,
   NativeModules,
   processColor,
 } from 'react-native';
 import SafeModule from 'react-native-safe-modules';
-import PropTypes from 'prop-types';
 
 const getNativeLottieViewForDesktop = () => {
   return requireNativeComponent('LottieAnimationView');
@@ -40,57 +38,6 @@ const LottieViewManager = Platform.select({
     },
   }),
 });
-
-const ViewStyleExceptBorderPropType = (props, propName, componentName, ...rest) => {
-  const flattened = StyleSheet.flatten(props[propName] || {});
-  const usesBorder = Object.keys(flattened).some(key => key.startsWith('border'));
-  if (usesBorder) {
-    return Error(
-      `${componentName} does not allow any border related style properties to be specified. ` +
-        "Border styles for this component will behave differently across platforms. If you'd " +
-        'like to render a border around this component, wrap it with a View.',
-    );
-  }
-  return ViewPropTypes.style(props, propName, componentName, ...rest);
-};
-
-const NotAllowedPropType = (props, propName, componentName) => {
-  const value = props[propName];
-  if (value != null) {
-    return Error(`${componentName} cannot specify '${propName}'.`);
-  }
-  return null;
-};
-
-const propTypes = {
-  ...ViewPropTypes,
-  style: ViewStyleExceptBorderPropType,
-  children: NotAllowedPropType,
-  resizeMode: PropTypes.oneOf(['cover', 'contain', 'center']),
-  progress: PropTypes.oneOfType([PropTypes.number, PropTypes.object]),
-  speed: PropTypes.number,
-  duration: PropTypes.number,
-  loop: PropTypes.bool,
-  autoPlay: PropTypes.bool,
-  autoSize: PropTypes.bool,
-  enableMergePathsAndroidForKitKatAndAbove: PropTypes.bool,
-  source: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
-  onAnimationFinish: PropTypes.func,
-  onLayout: PropTypes.func,
-  cacheComposition: PropTypes.bool,
-  colorFilters: PropTypes.arrayOf(PropTypes.shape({
-    keypath: PropTypes.string,
-    color: PropTypes.string
-  })),
-  textFiltersAndroid: PropTypes.arrayOf(PropTypes.shape({
-    find: PropTypes.string,
-    replace: PropTypes.string
-  })),
-  textFiltersIOS: PropTypes.arrayOf(PropTypes.shape({
-    keypath: PropTypes.string,
-    text: PropTypes.string
-  })),
-};
 
 const defaultProps = {
   progress: 0,
@@ -250,7 +197,6 @@ class LottieView extends React.PureComponent {
   }
 }
 
-LottieView.propTypes = propTypes;
 LottieView.defaultProps = defaultProps;
 
 module.exports = LottieView;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6096,7 +6096,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.5.10, prop-types@^15.7.2:
+prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==


### PR DESCRIPTION
React native recently completely removed ViewPropTypes, and static typing is now generally preferred over prop types. This removes prop types.

See https://github.com/facebook/react-native/commit/10199b158138b8645550b5579df87e654213fe42