### PR TITLE
Allow user press through lottie animation when pointerEvents='none'

### DIFF
--- a/src/js/LottieView.js
+++ b/src/js/LottieView.js
@@ -154,7 +154,7 @@ class LottieView extends React.PureComponent {
   }
 
   render() {
-    const { style, source, autoSize, ...rest } = this.props;
+    const { style, source, autoSize, pointerEvents, ...rest } = this.props;
 
     const sourceName = typeof source === 'string' ? source : undefined;
     const sourceJson = typeof source === 'string' ? undefined : JSON.stringify(source);
@@ -180,7 +180,7 @@ class LottieView extends React.PureComponent {
       : undefined;
 
     return (
-      <View style={[aspectRatioStyle, sizeStyle, style]}>
+      <View style={[aspectRatioStyle, sizeStyle, style]} pointerEvents={pointerEvents}>
         <AnimatedNativeLottieView
           ref={this.refRoot}
           {...rest}


### PR DESCRIPTION
React Native supports [pointerEvents](https://reactnative.dev/docs/view#pointerevents) but they don't work as expected with `LottieView`.

## Scenario
```jsx
<View>
  <LottieView 
    pointerEvents="none"
    style={{ position: 'absolute', zIndex: 1, width: 500 }}
    source={require('./someAnimation.json')}
    autoPlay={true}
  />
  <TextInput placeholder="Type here" />
</View>
```
- `LottieView` is absolutely positioned with zIndex of 1 so that animations play on top of existing content.  
- The `pointerEvents="none"` prop is added to `LottieView` so that lower zIndex components can receive touch events.
- It does not work as expected as the outermost `View` of `LottieView`'s implementation doesn't receive the prop.

## Proposed Solution
Let the outermost `View` receive the `pointerEvents` prop.

### Demo

#### Before
![NoTyping](https://user-images.githubusercontent.com/3091143/153973197-1251e5a1-5174-4aaf-8fb4-efe00c69ec8f.gif)
zIndex 0 never receives touch event.

#### After
![Typing](https://user-images.githubusercontent.com/3091143/153973200-ddade7e2-4f92-4363-93e7-e0d23f3197d3.gif)
zIndex 0 receives touch event as expected.
