### PR TITLE
Modify AnimationObject types for greater compatibility

### DIFF
--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -10,10 +10,11 @@ declare module "lottie-react-native" {
     op: number;
     w: number;
     h: number;
-    nm: string;
-    ddd: number;
+    nm?: string;
+    ddd?: number;
     assets: any[];
     layers: any[];
+    markers?: any[];
   }
 
   type ColorFilter = {


### PR DESCRIPTION
Just a minor update to the TypeScript definition to make the types compatible with more Lottie JSON files.

Makes the following properties optional:
 * `markers` is not always present in exported JSON files
 * `nm` is a name field that is optional when not using expressions
 * `ddd` flag for a 3D layer which defaults to `false` and can safely be removed from JSON files when compressing