### PR TITLE
Upgrade android lottie to 5.0.3

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -22,5 +22,5 @@ android {
 
 dependencies {
   implementation "com.facebook.react:react-native:+"
-  implementation 'com.airbnb.android:lottie:4.0.0'
+  implementation 'com.airbnb.android:lottie:5.0.3'
 }


### PR DESCRIPTION
Seems there have been some memory consumption improvements since v5.0.x of lottie-android. This PR updates the dependency to the latest version. https://github.com/airbnb/lottie-android/releases/tag/v5.0.1