### PR TITLE
fix: allow one to change lottie props and keep the animation running

### DIFF
--- a/src/ios/LottieReactNative/ContainerView.swift
+++ b/src/ios/LottieReactNative/ContainerView.swift
@@ -161,16 +161,21 @@ class ContainerView: RCTView {
     }
 
     func applyProperties() {
-        animationView?.currentProgress = progress
-        animationView?.animationSpeed = speed
-        animationView?.loopMode = loop
+        guard let animationView = animationView else { return }
+        let isPlaying = animationView.isAnimationPlaying
+        animationView.currentProgress = progress
+        animationView.animationSpeed = speed
+        animationView.loopMode = loop
         if (colorFilters.count > 0) {
             for filter in colorFilters {
                 let keypath: String = "\(filter.value(forKey: "keypath") as! String).**.Color"
                 let fillKeypath = AnimationKeypath(keypath: keypath)
                 let colorFilterValueProvider = ColorValueProvider((filter.value(forKey: "color") as! PlatformColor).lottieColorValue)
-                animationView?.setValueProvider(colorFilterValueProvider, keypath: fillKeypath)
+                animationView.setValueProvider(colorFilterValueProvider, keypath: fillKeypath)
             }
+        }
+        if isPlaying {
+           resume()
         }
     }
 }


### PR DESCRIPTION
If one tries to update colorFilters while the animation is running,
prior to this patch the animation would simple stop running.
This is caused because applyProperties() always sets
animationView.currentProgress, which according to the
docs stops the animation in case it's running.

In order to prevent such scenario the applyProperties()
will check if the animation is running before any updates.
After all props are updated, it will resume the animation in
case it was playing.

https://airbnb.io/lottie/#/ios?id=current-progress