### PR TITLE
chore(js): export AnimationObject

### DIFF
--- a/src/js/index.d.ts
+++ b/src/js/index.d.ts
@@ -3,7 +3,7 @@ declare module "lottie-react-native" {
   /**
    * Serialized animation as generated from After Effects
    */
-  interface AnimationObject {
+  export interface AnimationObject {
     v: string;
     fr: number;
     ip: number;


### PR DESCRIPTION
For projects that are using TS AnimationObject is necessary to determine the type of the image/animation.
Exporting it from the source would simplify that since we don't have to duplicate it locally.