### PR TITLE
Hotfix/view prop types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.0.0
+
+- Upgraded to RN 0.66.1
+- Support for PlatformColor
+
 ## 4.1.3
 
 - Added pod support for tvOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.1
+
+- Fix SimpleColorFilter casting error
+
 ## 5.0.0
 
 - Upgraded to RN 0.66.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lottie-react-native",
-  "version": "4.1.3",
+  "version": "5.0.0",
   "description": "React Native bindings for Lottie",
   "main": "lib/index.js",
   "types": "src/js/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lottie-react-native",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "React Native bindings for Lottie",
   "main": "lib/index.js",
   "types": "src/js/index.d.ts",

--- a/src/js/LottieView.js
+++ b/src/js/LottieView.js
@@ -6,7 +6,6 @@ import {
   View,
   Platform,
   StyleSheet,
-  ViewPropTypes,
   requireNativeComponent,
   NativeModules,
   processColor,

--- a/src/js/LottieView.js
+++ b/src/js/LottieView.js
@@ -10,6 +10,7 @@ import {
   NativeModules,
   processColor,
 } from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 import SafeModule from 'react-native-safe-modules';
 import PropTypes from 'prop-types';
 


### PR DESCRIPTION
It's a simple hotfix changing the ViewProTypes imports, to suppress warning log.