### PR TITLE
Upgrade android lottie to 5.1.1

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -22,5 +22,5 @@ android {
 
 dependencies {
   implementation "com.facebook.react:react-native:+"
-  implementation 'com.airbnb.android:lottie:5.0.3'
+  implementation 'com.airbnb.android:lottie:5.1.1'
 }


### PR DESCRIPTION
The android lottie team published a new update with some general improvements.

Ref: https://github.com/airbnb/lottie-android/releases/tag/v5.1.1