### PR TITLE
fix 'deprecated-react-native-prop-types could not be found' error

### DIFF
--- a/src/js/LottieView.js
+++ b/src/js/LottieView.js
@@ -10,7 +10,6 @@ import {
   NativeModules,
   processColor,
 } from 'react-native';
-import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 import SafeModule from 'react-native-safe-modules';
 
 const getNativeLottieViewForDesktop = () => {


### PR DESCRIPTION
It seems that older versions of react-native do not load `deprecated-react-native-prop-types`.

```
deprecated-react-native-prop-types could not be found within the project or in these directories:
  node_modules/lottie-react-native/node_modules
  node_modules

If you are sure the module exists, try these steps:
 1. Clear watchman watches: watchman watch-del-all
 2. Delete node_modules and run yarn install
 3. Reset Metro's cache: yarn start --reset-cache
 4. Remove the cache: rm -rf /tmp/metro-*
```

ViewPropType is no longer used in e1f409b and has been removed.
Alternatively, I would like to see `deprecated-react-native-prop-types` added to the dependencies in package.json.