### PR TITLE
chore: remove lottie-ios peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ For the first time, designers can create **and ship** beautiful animations witho
 ## Installing
 
 ### iOS and Android
-Install `lottie-react-native` (latest) and `lottie-ios` (3.4.0):
+Install `lottie-react-native` (latest):
 
 ```
-yarn add lottie-react-native lottie-ios@3.4.0
+yarn add lottie-react-native
 ```
 
 or
 
 ```
-npm i --save lottie-react-native lottie-ios@3.4.0
+npm i --save lottie-react-native
 ```
 
 Go to your ios folder and run:
@@ -96,7 +96,7 @@ Depending on which version of React Native your app runs on you might need to in
 | >= 0.60       | 4.0.2 | 3.2.3 
 | >= 0.63       | 4.0.3 | 3.2.3 
 | >= 0.64       | 4.1.3 | 3.2.3 
-| >= 0.66       | latest | 3.4.0 
+| >= 0.66       | latest | 3.4.1 
 
 ## Usage
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -299,7 +299,6 @@ DEPENDENCIES:
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
-  - lottie-ios (from `../node_modules/lottie-ios`)
   - lottie-react-native (from `../node_modules/lottie-react-native`)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
@@ -335,6 +334,7 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - fmt
+    - lottie-ios
 
 EXTERNAL SOURCES:
   boost:
@@ -347,8 +347,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/React/FBReactNativeSpec"
   glog:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
-  lottie-ios:
-    :path: "../node_modules/lottie-ios"
   lottie-react-native:
     :path: "../node_modules/lottie-react-native"
   RCT-Folly:
@@ -414,10 +412,10 @@ SPEC CHECKSUMS:
   FBLazyVector: a7a655862f6b09625d11c772296b01cd5164b648
   FBReactNativeSpec: 81ce99032d5b586fddd6a38d450f8595f7e04be4
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 5337263514dd6f09803962437687240c5dc39aa4
+  glog: 476ee3e89abb49e07f822b48323c51c57124b572
   lottie-ios: 016449b5d8be0c3dcbcfa0a9988469999cd04c5d
   lottie-react-native: da7af021c13d9f1805253245248c492be8fc0924
-  RCT-Folly: a21c126816d8025b547704b777a2ba552f3d9fa9
+  RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
   RCTRequired: 3e917ea5377751094f38145fdece525aa90545a0
   RCTTypeSafety: c43c072a4bd60feb49a9570b0517892b4305c45e
   React: 176dd882de001854ced260fad41bb68a31aa4bd0

--- a/example/package.json
+++ b/example/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@react-native-community/slider": "^4.2.2",
     "@react-native-picker/picker": "^2.4.1",
-    "lottie-ios": "^3.4.1",
     "lottie-react-native": "file:..",
     "react": "17.0.2",
     "react-native": "0.68.2",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -4844,11 +4844,6 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-lottie-ios@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/lottie-ios/-/lottie-ios-3.4.1.tgz#1c264066d1df04644f970cce4c2f82e27086c660"
-  integrity sha512-oZh9BcCMicLFeKC0KO5cfJ6Pzb+qfB7qZ4vqh5R+buXcCRZKnFhHkt9TZfd62ZJi2XC3kirXYVYyU7c+jqpo9g==
-
 "lottie-react-native@file:..":
   version "5.1.4"
   dependencies:

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "homepage": "https://github.com/airbnb/lottie-react-native#readme",
   "peerDependencies": {
-    "lottie-ios": "^3.4.1",
     "react": "*",
     "react-native": ">=0.46",
     "react-native-windows": ">=0.63.x"


### PR DESCRIPTION
## Problem
Users need to install `lottie-ios` compatible with their `lottie-react-native` version in order to use library.

## Action
As we are moving forward, I think it is good to remove peer dependency and depend on podspec to install the proper version from podspec without manually installing `lottie-ios` on the project.  
From now on, `lottie-ios` can be installed and detected automatically from podspec configuration and users do not need to install both of them in order to use it. 

## Checklist
- [x] Test iOS build