### PR TITLE
Remove render mode fallback for used text filters on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Depending on which version of React Native your app runs on you might need to in
 | >= 0.60       | 4.0.2 | 3.2.3 
 | >= 0.63       | 4.0.3 | 3.2.3 
 | >= 0.64       | 4.1.3 | 3.2.3 
-| >= 0.66       | latest | 3.4.1 
+| >= 0.66       | latest | 3.4.3 
 
 ## Usage
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -11,9 +11,9 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.68.2)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - lottie-ios (3.4.1)
+  - lottie-ios (3.4.3)
   - lottie-react-native (5.1.4):
-    - lottie-ios (~> 3.4.1)
+    - lottie-ios (~> 3.4.3)
     - React-Core
   - RCT-Folly (2021.06.28.00-v2):
     - boost
@@ -413,8 +413,8 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 81ce99032d5b586fddd6a38d450f8595f7e04be4
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 476ee3e89abb49e07f822b48323c51c57124b572
-  lottie-ios: 016449b5d8be0c3dcbcfa0a9988469999cd04c5d
-  lottie-react-native: da7af021c13d9f1805253245248c492be8fc0924
+  lottie-ios: 9ae750cdc7820fecbd3c2f0cfc493038208fcdc4
+  lottie-react-native: 1adad1c27f4a1f3f377aaeb3eb3f7cba7b23b30f
   RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
   RCTRequired: 3e917ea5377751094f38145fdece525aa90545a0
   RCTTypeSafety: c43c072a4bd60feb49a9570b0517892b4305c45e

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -11,9 +11,9 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.68.2)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - lottie-ios (3.4.3)
+  - lottie-ios (3.5.0)
   - lottie-react-native (5.1.4):
-    - lottie-ios (~> 3.4.3)
+    - lottie-ios (~> 3.5.0)
     - React-Core
   - RCT-Folly (2021.06.28.00-v2):
     - boost
@@ -412,10 +412,10 @@ SPEC CHECKSUMS:
   FBLazyVector: a7a655862f6b09625d11c772296b01cd5164b648
   FBReactNativeSpec: 81ce99032d5b586fddd6a38d450f8595f7e04be4
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 476ee3e89abb49e07f822b48323c51c57124b572
-  lottie-ios: 9ae750cdc7820fecbd3c2f0cfc493038208fcdc4
-  lottie-react-native: 1adad1c27f4a1f3f377aaeb3eb3f7cba7b23b30f
-  RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
+  glog: 5337263514dd6f09803962437687240c5dc39aa4
+  lottie-ios: c55158d67d0629a260625cc2ded2052b829e3c3e
+  lottie-react-native: 266c1954465f3f81e742f4d61a2b665f2f123794
+  RCT-Folly: a21c126816d8025b547704b777a2ba552f3d9fa9
   RCTRequired: 3e917ea5377751094f38145fdece525aa90545a0
   RCTTypeSafety: c43c072a4bd60feb49a9570b0517892b4305c45e
   React: 176dd882de001854ced260fad41bb68a31aa4bd0

--- a/ios/LottieReactNative/ContainerView.swift
+++ b/ios/LottieReactNative/ContainerView.swift
@@ -72,8 +72,7 @@ class ContainerView: RCTView {
 
     func getLottieConfiguration() -> LottieConfiguration {
         return LottieConfiguration(
-            // Text Providers is not supported for Core Animation render engine
-            renderingEngine: textFilters.count > 0 ? .mainThread : renderMode
+            renderingEngine: renderMode
         )
     }
        

--- a/lottie-react-native.podspec
+++ b/lottie-react-native.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.swift_version = "5.0"
 
   s.dependency 'React-Core'
-  s.dependency 'lottie-ios', '~> 3.4.1'
+  s.dependency 'lottie-ios', '~> 3.4.3'
 end

--- a/lottie-react-native.podspec
+++ b/lottie-react-native.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.swift_version = "5.0"
 
   s.dependency 'React-Core'
-  s.dependency 'lottie-ios', '~> 3.4.3'
+  s.dependency 'lottie-ios', '~> 3.5.0'
 end


### PR DESCRIPTION
The [new patch version](https://github.com/airbnb/lottie-ios/releases/tag/3.4.3) of lottie-ios already supports the text provider on the new CoreAnimation rendering engine, so we don't need a fallback anymore.