### PR TITLE
Update README.md for more consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install `lottie-react-native` (latest):
 yarn add lottie-react-native
 ```
 
-For `lottie-react-native` <= 5.1.4 you also need to install `lottie-ios@3.4.1` package:
+For `lottie-react-native` >= 5.1.4 no need to install lottie-ios separaretly:
 ```
 yarn add lottie-ios@3.4.1
 ```
@@ -98,7 +98,7 @@ Depending on which version of React Native your app runs on you might need to in
 | >= 0.63       | 4.0.3 | 3.2.3 
 | >= 0.64       | 4.1.3 | 3.2.3 
 | >= 0.66       | > 4.1.3 and <= 5.1.4 | 3.4.1 
-| >= 0.66       | > 5.1.4 | No need to install `lottie-ios` separaretly
+| >= 0.66       | >= 5.1.4 | No need to install `lottie-ios` separaretly
 
 ## Usage
 


### PR DESCRIPTION
For the version of `lottie-react-native 5.1.4` no need to be installed separately since `lottie-ios` is installed automatically to `v3.4.4`, and then there is no limitation to have only the main dependency `lottie-react-native`.

<img width="878" alt="Screenshot 2022-12-20 at 21 24 27" src="https://user-images.githubusercontent.com/4986411/208760552-e8dafcc5-2242-43de-993a-915a786f92a5.png">

<img width="887" alt="Screenshot 2022-12-20 at 20 56 36" src="https://user-images.githubusercontent.com/4986411/208760706-ceeaab70-97b3-4fcb-a209-2c7fbcc9176d.png">

Tested on iOS devices.
