### PR TITLE
fix(iOS): reset to first frame on app resume bug

### DIFF
--- a/packages/core/ios/LottieReactNative/ContainerView.swift
+++ b/packages/core/ios/LottieReactNative/ContainerView.swift
@@ -25,7 +25,7 @@ class ContainerView: RCTView {
         super.traitCollectionDidChange(previousTraitCollection)
         if #available(iOS 13.0, tvOS 13.0, *) {
             if (self.traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
-                applyProperties()
+                applyColorProperties()
                 print("dark mode changed")
             }
         }
@@ -194,7 +194,7 @@ class ContainerView: RCTView {
 
     @objc func setColorFilters(_ newColorFilters: [NSDictionary]) {
         colorFilters = newColorFilters
-        applyProperties()
+        applyColorProperties()
     }
 
     // There is no Nullable CGFloat in Objective-C, so this function uses a Nullable NSNumber and converts it later
@@ -210,9 +210,11 @@ class ContainerView: RCTView {
                 onFinish(["isCancelled": !animationFinished])
             }
             self.delegate?.onAnimationFinish(isCancelled: !animationFinished);
+            if (animationFinished) {
+                self.animationView?.currentProgress = 1;
+            }
         }
 
-        animationView?.backgroundBehavior = .pauseAndRestore
         animationView?.play(fromFrame: fromFrame, toFrame: toFrame, loopMode: self.loop, completion: callback);
     }
 
@@ -221,10 +223,12 @@ class ContainerView: RCTView {
             if let onFinish = self.onAnimationFinish {
                 onFinish(["isCancelled": !animationFinished])
             }
+            if (animationFinished) {
+                self.animationView?.currentProgress = 1;
+            }
             self.delegate?.onAnimationFinish(isCancelled: !animationFinished);
         }
 
-        animationView?.backgroundBehavior = .pauseAndRestore
         animationView?.play(completion: callback)
     }
 
@@ -257,15 +261,15 @@ class ContainerView: RCTView {
         addSubview(next)
         animationView?.contentMode = contentMode
         animationView?.reactSetFrame(frame)
-        applyProperties()
+        animationView?.backgroundBehavior = .pauseAndRestore
+        animationView?.animationSpeed = speed
+        animationView?.loopMode = loop
+        applyColorProperties()
     }
-
-    func applyProperties() {
+    
+    func applyColorProperties() {
         guard let animationView = animationView else { return }
-        let isPlaying = animationView.isAnimationPlaying
-        animationView.currentProgress = progress
-        animationView.animationSpeed = speed
-        animationView.loopMode = loop
+
         if (colorFilters.count > 0) {
             for filter in colorFilters {
                 let keypath: String = "\(filter.value(forKey: "keypath") as! String).**.Color"
@@ -273,9 +277,6 @@ class ContainerView: RCTView {
                 let colorFilterValueProvider = ColorValueProvider((filter.value(forKey: "color") as! PlatformColor).lottieColorValue)
                 animationView.setValueProvider(colorFilterValueProvider, keypath: fillKeypath)
             }
-        }
-        if isPlaying {
-           resume()
         }
     }
 }

--- a/packages/core/ios/LottieReactNative/ContainerView.swift
+++ b/packages/core/ios/LottieReactNative/ContainerView.swift
@@ -204,32 +204,25 @@ class ContainerView: RCTView {
         play(fromFrame: convertedFromFrame, toFrame: toFrame);
     }
     
-    func play(fromFrame: AnimationFrameTime? = nil, toFrame: AnimationFrameTime) {
-        let callback: LottieCompletionBlock = { animationFinished in
+    func getCompletionCallback() -> LottieCompletionBlock {
+        return { animationFinished in
             if let onFinish = self.onAnimationFinish {
                 onFinish(["isCancelled": !animationFinished])
             }
             self.delegate?.onAnimationFinish(isCancelled: !animationFinished);
             if (animationFinished) {
+                // Force the animation to stay on the last frame when the animation ends
                 self.animationView?.currentProgress = 1;
             }
-        }
-
-        animationView?.play(fromFrame: fromFrame, toFrame: toFrame, loopMode: self.loop, completion: callback);
+        };
+    }
+    
+    func play(fromFrame: AnimationFrameTime? = nil, toFrame: AnimationFrameTime) {
+        animationView?.play(fromFrame: fromFrame, toFrame: toFrame, loopMode: self.loop, completion: getCompletionCallback());
     }
 
     @objc func play() {
-        let callback: LottieCompletionBlock = { animationFinished in
-            if let onFinish = self.onAnimationFinish {
-                onFinish(["isCancelled": !animationFinished])
-            }
-            if (animationFinished) {
-                self.animationView?.currentProgress = 1;
-            }
-            self.delegate?.onAnimationFinish(isCancelled: !animationFinished);
-        }
-
-        animationView?.play(completion: callback)
+        animationView?.play(completion: getCompletionCallback())
     }
 
     @objc func reset() {


### PR DESCRIPTION
This fixes the bug where the animation resets to its first frame when going to background and resume.
Issue: https://github.com/lottie-react-native/lottie-react-native/issues/825

## Why this problem occured?
When going to background, `traitCollectionDidChange` method runs which calls `applyProperties()`. This changes the animation's current progress `animationView.currentProgress = progress` and `progress` comes from props. If not defined it defaults to 0 (first frame).

Additionally, setting `backgroundBehavior = .pauseAndRestore` has a weird behavior. When the animation ends and the app goes to background, it sets the animation to the first frame. Forcing the `currentProgress` to the last frame when the animation ends works fine to mitigate the issue.

## Before 
https://user-images.githubusercontent.com/3791120/215833991-ec57dd77-9f7e-4802-b846-0df7f9a42cbf.mov

## After
https://user-images.githubusercontent.com/3791120/215833635-af090c2f-e6cb-4367-b152-bce21b1419b7.mov
