### PR TITLE
fix: refactor event dispatch logic on android to fix fabric crash

### DIFF
--- a/packages/core/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManagerImpl.kt
+++ b/packages/core/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManagerImpl.kt
@@ -2,26 +2,25 @@ package com.airbnb.android.react.lottie
 
 import android.os.Handler
 import android.os.Looper
-import android.util.Log
 import android.view.View
 import android.view.View.OnAttachStateChangeListener
 import android.widget.ImageView
 import androidx.core.view.ViewCompat
 import com.airbnb.lottie.LottieAnimationView
 import com.airbnb.lottie.RenderMode
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.common.MapBuilder
 import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.util.RNLog
 import kotlinx.coroutines.*
 import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.net.URL
-import kotlin.concurrent.thread
 
 internal object LottieAnimationViewManagerImpl {
     const val REACT_CLASS = "LottieAnimationView"
-    val coroutineScope = CoroutineScope(Dispatchers.Main)
 
     @JvmStatic
     val exportedViewConstants: Map<String, Any>
@@ -37,10 +36,26 @@ internal object LottieAnimationViewManagerImpl {
     }
 
     @JvmStatic
-    fun getExportedCustomBubblingEventTypeConstants(): MutableMap<String, Any> {
+    fun sendOnAnimationFinishEvent(view: LottieAnimationView, isCancelled: Boolean) {
+        val event = Arguments.createMap()
+        event.putBoolean("isCancelled", isCancelled)
+
+        val screenContext = view.context as ThemedReactContext
+        val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(screenContext, view.id)
+        eventDispatcher?.dispatchEvent(
+            OnAnimationFinishEvent(
+                screenContext.surfaceId,
+                view.id,
+                isCancelled
+            )
+        )
+    }
+
+    @JvmStatic
+    fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
         return MapBuilder.of(
-            "animationFinish",
-            MapBuilder.of("phasedRegistrationNames", MapBuilder.of("bubbled", "onAnimationFinish"))
+            OnAnimationFinishEvent.EVENT_NAME,
+            MapBuilder.of("registrationName", "onAnimationFinish"),
         )
     }
 

--- a/packages/core/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManagerImpl.kt
+++ b/packages/core/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManagerImpl.kt
@@ -8,7 +8,6 @@ import android.widget.ImageView
 import androidx.core.view.ViewCompat
 import com.airbnb.lottie.LottieAnimationView
 import com.airbnb.lottie.RenderMode
-import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.common.MapBuilder
 import com.facebook.react.uimanager.ThemedReactContext
@@ -37,9 +36,6 @@ internal object LottieAnimationViewManagerImpl {
 
     @JvmStatic
     fun sendOnAnimationFinishEvent(view: LottieAnimationView, isCancelled: Boolean) {
-        val event = Arguments.createMap()
-        event.putBoolean("isCancelled", isCancelled)
-
         val screenContext = view.context as ThemedReactContext
         val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(screenContext, view.id)
         eventDispatcher?.dispatchEvent(

--- a/packages/core/android/src/main/java/com/airbnb/android/react/lottie/LottiePackage.kt
+++ b/packages/core/android/src/main/java/com/airbnb/android/react/lottie/LottiePackage.kt
@@ -13,6 +13,6 @@ class LottiePackage : ReactPackage {
     }
 
     override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
-        return listOf(LottieAnimationViewManager(reactContext))
+        return listOf(LottieAnimationViewManager())
     }
 }

--- a/packages/core/android/src/main/java/com/airbnb/android/react/lottie/OnAnimationFinishEvent.kt
+++ b/packages/core/android/src/main/java/com/airbnb/android/react/lottie/OnAnimationFinishEvent.kt
@@ -1,0 +1,26 @@
+package com.airbnb.android.react.lottie
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+
+class OnAnimationFinishEvent
+constructor(surfaceId: Int, viewId: Int, private val isCancelled: Boolean) :
+    Event<OnAnimationFinishEvent>(surfaceId, viewId) {
+
+    override fun getEventName(): String {
+        return EVENT_NAME
+    }
+
+    override fun getCoalescingKey(): Short = 0
+
+    override fun getEventData(): WritableMap? {
+        val event = Arguments.createMap()
+        event.putBoolean("isCancelled", isCancelled)
+        return event
+    }
+
+    companion object {
+        const val EVENT_NAME = "topAnimationFinish"
+    }
+}

--- a/packages/core/android/src/newarch/com/airbnb/android/react/lottie/LottieAnimationViewManager.kt
+++ b/packages/core/android/src/newarch/com/airbnb/android/react/lottie/LottieAnimationViewManager.kt
@@ -1,7 +1,6 @@
 package com.airbnb.android.react.lottie
 
 import android.animation.Animator
-import android.util.Log
 import com.airbnb.android.react.lottie.LottieAnimationViewManagerImpl.setColorFilters
 import com.airbnb.android.react.lottie.LottieAnimationViewManagerImpl.setEnableMergePaths
 import com.airbnb.android.react.lottie.LottieAnimationViewManagerImpl.setHardwareAcceleration
@@ -17,25 +16,19 @@ import com.airbnb.android.react.lottie.LottieAnimationViewManagerImpl.setSpeed
 import com.airbnb.android.react.lottie.LottieAnimationViewManagerImpl.setTextFilters
 import com.airbnb.android.react.lottie.LottieAnimationViewManagerImpl.setAutoPlay
 import com.airbnb.lottie.LottieAnimationView
-import com.facebook.react.bridge.Arguments
-import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReadableArray
-import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
-import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.uimanager.annotations.ReactProp
-import com.facebook.react.uimanager.events.Event
-import com.facebook.react.uimanager.events.RCTEventEmitter
-import com.facebook.react.uimanager.events.RCTModernEventEmitter
 import com.facebook.react.viewmanagers.LottieAnimationViewManagerDelegate
 import com.facebook.react.viewmanagers.LottieAnimationViewManagerInterface
 import java.util.*
 
 @ReactModule(name = LottieAnimationViewManagerImpl.REACT_CLASS)
-class LottieAnimationViewManager(val reactContext: ReactContext) :
+class LottieAnimationViewManager :
     SimpleViewManager<LottieAnimationView>(),
     LottieAnimationViewManagerInterface<LottieAnimationView> {
     private val propManagersMap =
@@ -53,22 +46,6 @@ class LottieAnimationViewManager(val reactContext: ReactContext) :
             propManagersMap[view] = result
         }
         return result
-    }
-
-    private fun sendOnAnimationFinishEvent(view: LottieAnimationView, isCancelled: Boolean) {
-        val event = Arguments.createMap()
-        event.putBoolean("isCancelled", isCancelled)
-
-        val screenContext = view.context as ThemedReactContext
-
-        Log.d("Lottie", "view surface id ${screenContext.surfaceId} - view id ${view.id}")
-        reactContext.getJSModule(RCTModernEventEmitter::class.java)
-            ?.receiveEvent(
-                screenContext.surfaceId,
-                view.id,
-                "animationFinish",
-                event
-            )
     }
 
     override fun getDelegate(): ViewManagerDelegate<LottieAnimationView> {
@@ -91,13 +68,11 @@ class LottieAnimationViewManager(val reactContext: ReactContext) :
             }
 
             override fun onAnimationEnd(animation: Animator) {
-//                TODO: fix crash
-//                sendOnAnimationFinishEvent(view, false)
+                LottieAnimationViewManagerImpl.sendOnAnimationFinishEvent(view, false)
             }
 
             override fun onAnimationCancel(animation: Animator) {
-//                TODO: fix crash
-//                sendOnAnimationFinishEvent(view, true)
+                LottieAnimationViewManagerImpl.sendOnAnimationFinishEvent(view, true)
             }
 
             override fun onAnimationRepeat(animation: Animator) {
@@ -107,8 +82,8 @@ class LottieAnimationViewManager(val reactContext: ReactContext) :
         return view
     }
 
-    override fun getExportedCustomBubblingEventTypeConstants(): Map<String, Any> {
-        return LottieAnimationViewManagerImpl.getExportedCustomBubblingEventTypeConstants()
+    override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any>? {
+        return LottieAnimationViewManagerImpl.getExportedCustomDirectEventTypeConstants()
     }
 
     override fun onAfterUpdateTransaction(view: LottieAnimationView) {

--- a/packages/core/android/src/oldarch/com/airbnb/android/react/lottie/LottieAnimationViewManager.kt
+++ b/packages/core/android/src/oldarch/com/airbnb/android/react/lottie/LottieAnimationViewManager.kt
@@ -1,5 +1,3 @@
-@file:Suppress("unused", "DEPRECATION")
-
 package com.airbnb.android.react.lottie
 
 import android.animation.Animator
@@ -22,21 +20,18 @@ import com.airbnb.android.react.lottie.LottieAnimationViewManagerImpl.setSourceU
 import com.airbnb.android.react.lottie.LottieAnimationViewManagerImpl.setSpeed
 import com.airbnb.android.react.lottie.LottieAnimationViewManagerImpl.setTextFilters
 import com.airbnb.lottie.LottieAnimationView
-import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
-import com.facebook.react.bridge.ReactContext
 import com.facebook.react.uimanager.annotations.ReactProp
-import com.facebook.react.uimanager.events.RCTEventEmitter
 import java.util.*
 
-class LottieAnimationViewManager(val reactContext: ReactContext): SimpleViewManager<LottieAnimationView>() {
+class LottieAnimationViewManager : SimpleViewManager<LottieAnimationView>() {
     private val propManagersMap =
-            WeakHashMap<LottieAnimationView, LottieAnimationViewPropertyManager>()
+        WeakHashMap<LottieAnimationView, LottieAnimationViewPropertyManager>()
 
     private fun getOrCreatePropertyManager(
-            view: LottieAnimationView
+        view: LottieAnimationView
     ): LottieAnimationViewPropertyManager {
         var result = propManagersMap[view]
         if (result == null) {
@@ -44,18 +39,6 @@ class LottieAnimationViewManager(val reactContext: ReactContext): SimpleViewMana
             propManagersMap[view] = result
         }
         return result
-    }
-
-    private fun sendOnAnimationFinishEvent(view: LottieAnimationView, isCancelled: Boolean) {
-        val event = Arguments.createMap()
-        event.putBoolean("isCancelled", isCancelled)
-
-        val screenContext = view.context
-        if (screenContext is ThemedReactContext) {
-            screenContext
-                    .getJSModule(RCTEventEmitter::class.java)
-                    ?.receiveEvent(view.id, "animationFinish", event)
-        }
     }
 
     override fun getExportedViewConstants(): Map<String, Any> {
@@ -69,35 +52,35 @@ class LottieAnimationViewManager(val reactContext: ReactContext): SimpleViewMana
     public override fun createViewInstance(context: ThemedReactContext): LottieAnimationView {
         val view = LottieAnimationViewManagerImpl.createViewInstance(context)
         view.addAnimatorListener(
-                object : Animator.AnimatorListener {
-                    override fun onAnimationStart(animation: Animator) {
-                        // do nothing
-                    }
-
-                    override fun onAnimationEnd(animation: Animator) {
-                        sendOnAnimationFinishEvent(view, false)
-                    }
-
-                    override fun onAnimationCancel(animation: Animator) {
-                        sendOnAnimationFinishEvent(view, true)
-                    }
-
-                    override fun onAnimationRepeat(animation: Animator) {
-                        // do nothing
-                    }
+            object : Animator.AnimatorListener {
+                override fun onAnimationStart(animation: Animator) {
+                    // do nothing
                 }
+
+                override fun onAnimationEnd(animation: Animator) {
+                    LottieAnimationViewManagerImpl.sendOnAnimationFinishEvent(view, false)
+                }
+
+                override fun onAnimationCancel(animation: Animator) {
+                    LottieAnimationViewManagerImpl.sendOnAnimationFinishEvent(view, true)
+                }
+
+                override fun onAnimationRepeat(animation: Animator) {
+                    // do nothing
+                }
+            }
         )
         return view
     }
 
-    override fun getExportedCustomBubblingEventTypeConstants(): Map<String, Any> {
-        return LottieAnimationViewManagerImpl.getExportedCustomBubblingEventTypeConstants()
+    override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any>? {
+        return LottieAnimationViewManagerImpl.getExportedCustomDirectEventTypeConstants()
     }
 
     override fun receiveCommand(
-            view: LottieAnimationView,
-            commandName: String,
-            args: ReadableArray?
+        view: LottieAnimationView,
+        commandName: String,
+        args: ReadableArray?
     ) {
         when (commandName) {
             "play" -> play(view, args?.getInt(0) ?: -1, args?.getInt(1) ?: -1)
@@ -142,8 +125,8 @@ class LottieAnimationViewManager(val reactContext: ReactContext): SimpleViewMana
 
     @ReactProp(name = "hardwareAccelerationAndroid")
     fun setHardwareAccelerationAndroid(
-            view: LottieAnimationView,
-            hardwareAccelerationAndroid: Boolean?
+        view: LottieAnimationView,
+        hardwareAccelerationAndroid: Boolean?
     ) {
         setHardwareAcceleration(hardwareAccelerationAndroid!!, getOrCreatePropertyManager(view))
     }


### PR DESCRIPTION
fixes https://github.com/lottie-react-native/lottie-react-native/issues/963

This PR refactors the event dispatch logic on Android and makes use of the EventDispatcher on paper and fabric. I did a test in both architectures via the example project and was successfully able to see the relevant console log which is running when an animation finishes.

cc @matinzd @alfonsocj @emilioicai