### PR TITLE
chore: remove redundant logging from the project 

### DIFF
--- a/packages/core/ios/LottieReactNative/ContainerView.swift
+++ b/packages/core/ios/LottieReactNative/ContainerView.swift
@@ -31,7 +31,6 @@ class ContainerView: RCTView {
         if #available(iOS 13.0, tvOS 13.0, *) {
             if (self.traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
                 applyColorProperties()
-                print("dark mode changed")
             }
         }
     }


### PR DESCRIPTION
This PR removes the `print("dark mode changed")` from the project.

This screenshot is from my work project where I use lottie.

![image](https://github.com/lottie-react-native/lottie-react-native/assets/32423942/4b23eff6-9d35-41ef-b75f-e038bdbcd20b)

