### PR TITLE
Override `frame` in addition to `bounds`

### DIFF
--- a/packages/core/ios/LottieReactNative/ContainerView.swift
+++ b/packages/core/ios/LottieReactNative/ContainerView.swift
@@ -251,6 +251,12 @@ class ContainerView: RCTView {
             animationView?.reactSetFrame(self.bounds)
         }
     }
+
+    override var frame: CGRect {
+        didSet {
+            animationView?.reactSetFrame(self.bounds)
+        }
+    }
     
     // MARK: Private
     func replaceAnimationView(next: LottieAnimationView) {


### PR DESCRIPTION
In some cases (on the new architecture`) the frame of the `animationView` was not set correctly by the overridden `bounds`, while the `frame` was receiving the correct position & size.

I've added an override for `frame` which functions in the exact same way as the one for `bounds` and it solved the problem.