### PR TITLE
feat: registration compat for 0.68/0.69

### DIFF
--- a/packages/core/android/Android.mk
+++ b/packages/core/android/Android.mk
@@ -1,0 +1,45 @@
+THIS_DIR := $(call my-dir)
+
+include $(REACT_ANDROID_DIR)/Android-prebuilt.mk
+
+include ${GENERATED_SRC_DIR}/codegen/jni/Android.mk
+
+include $(CLEAR_VARS)
+
+LOCAL_PATH := $(THIS_DIR)
+
+# Define the library name here.
+LOCAL_MODULE := ${CODEGEN_MODULE_NAME}_registration
+
+LOCAL_SRC_FILES := $(wildcard $(LOCAL_PATH)/*.cpp)
+
+LOCAL_SHARED_LIBRARIES := \
+  libfabricjni \
+  libfbjni \
+  libglog \
+  libjsi \
+  libreact_codegen_rncore \
+  libreact_codegen_${CODEGEN_MODULE_NAME} \
+  libreact_debug \
+  libreact_nativemodule_core \
+  libreact_render_componentregistry \
+  libreact_render_core \
+  libreact_render_debug \
+  libreact_render_graphics \
+  librrc_view \
+  libruntimeexecutor \
+  libturbomodulejsijni \
+  libyoga
+
+ifneq ($(filter $(call modules-get-list),folly_runtime),)
+  LOCAL_SHARED_LIBRARIES += libfolly_runtime # since react-native@0.69
+else
+  LOCAL_SHARED_LIBRARIES += libfolly_futures libfolly_json # react-native@0.68
+endif
+
+LOCAL_CFLAGS := \
+  -DLOG_TAG=\"ReactNative\" \
+  -DCODEGEN_COMPONENT_DESCRIPTOR_H="<react/renderer/components/${CODEGEN_MODULE_NAME}/ComponentDescriptors.h>"
+LOCAL_CFLAGS += -fexceptions -frtti -std=c++17 -Wall
+
+include $(BUILD_SHARED_LIBRARY)

--- a/packages/core/android/build.gradle
+++ b/packages/core/android/build.gradle
@@ -32,6 +32,27 @@ if (isNewArchitectureEnabled()) {
     apply plugin: 'com.facebook.react'
 }
 
+import groovy.json.JsonSlurper
+
+// https://github.com/callstack/react-native-builder-bob/discussions/359
+def registrationCompat = {
+  def reactNativeManifest = file("$projectDir/../../react-native/package.json")
+  def reactNativeVersion = new JsonSlurper().parseText(reactNativeManifest.text).version as String
+  // Fabric was introduced at react-native@0.68, full CMake support were introduced at react-native@0.71
+  // Use Android.mk for compatibility with react-native@0.68/0.69
+  reactNativeVersion.matches('(0.68.*|0.69.*)')
+}()
+
+def codegenViewLibraryName = "lottiereactnative"
+def codegenViewModuleName = {
+  // Autolink for Fabric uses codegenConfig.name in package.json since react-native@0.70
+  // Use codegenViewLibraryName for compatibility with react-native@0.68/0.69
+  def libraryManifestJson = new JsonSlurper().parseText(file("$projectDir/../package.json").text)
+  registrationCompat ? codegenViewLibraryName : libraryManifestJson.codegenConfig.name
+}()
+
+def appProject = rootProject.allprojects.find { it.plugins.hasPlugin('com.android.application') }
+
 android {
     def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
     // Check AGP version for backward compatibility reasons
@@ -57,6 +78,36 @@ android {
 
         ndk {
             abiFilters(*reactNativeArchitectures())
+        }
+
+        buildConfigField "String", "CODEGEN_MODULE_REGISTRATION", (isNewArchitectureEnabled() && registrationCompat ? "\"${codegenViewModuleName}_registration\"" : "null")
+
+        if (isNewArchitectureEnabled() && registrationCompat) {
+            def reactAndroidProject = project(':ReactAndroid')
+            externalNativeBuild {
+                ndkBuild {
+                    arguments "APP_PLATFORM=android-21",
+                                "APP_STL=c++_shared",
+                                "NDK_TOOLCHAIN_VERSION=clang",
+                                "GENERATED_SRC_DIR=$buildDir/generated/source", // for react_codegen_* in this library's codegen/jni
+                                "PROJECT_BUILD_DIR=${appProject.buildDir}", // for REACT_NDK_EXPORT_DIR in ReactAndroid's Android-prebuilt.mk
+                                "REACT_ANDROID_DIR=${reactAndroidProject.projectDir}",
+                                "REACT_ANDROID_BUILD_DIR=${reactAndroidProject.buildDir}",
+                                "CODEGEN_MODULE_NAME=$codegenViewModuleName"
+                    cFlags "-Wall", "-Werror", "-fexceptions", "-frtti", "-DWITH_INSPECTOR=1"
+                    cppFlags "-std=c++17"
+                    targets "${codegenViewModuleName}_registration"
+                }
+            }
+        }
+    }
+
+    if (isNewArchitectureEnabled() && registrationCompat) {
+        // We configure the NDK build only if you decide to opt-in for the New Architecture.
+        externalNativeBuild {
+            ndkBuild {
+                path "Android.mk"
+            }
         }
     }
 
@@ -130,7 +181,26 @@ if (isNewArchitectureEnabled()) {
   // Use react{} for compatibility with react-native@0.68/0.69
   react {
     jsRootDir = file("../src/specs")
-    libraryName = 'lottiereactnative'
+    libraryName = codegenViewLibraryName
     codegenJavaPackageName = "com.airbnb.android.react.lottie"
+  }
+
+  afterEvaluate {
+    preDebugBuild.dependsOn appProject.tasks['preDebugBuild']
+    preReleaseBuild.dependsOn appProject.tasks['preReleaseBuild']
+
+    // Due to a bug inside AGP, we have to explicitly set a dependency
+    // between configureNdkBuild* tasks and the preBuild tasks.
+    // This can be removed once this is solved: https://issuetracker.google.com/issues/207403732
+    tasks.findByName('configureNdkBuildDebug')?.dependsOn preDebugBuild
+    tasks.findByName('configureNdkBuildRelease')?.dependsOn preReleaseBuild
+    reactNativeArchitectures().each { architecture ->
+      tasks.findByName("configureNdkBuildDebug[${architecture}]")?.configure {
+        dependsOn("preDebugBuild")
+      }
+      tasks.findByName("configureNdkBuildRelease[${architecture}]")?.configure {
+        dependsOn("preReleaseBuild")
+      }
+    }
   }
 }

--- a/packages/core/android/registration.cpp
+++ b/packages/core/android/registration.cpp
@@ -1,0 +1,18 @@
+#include <CoreComponentsRegistry.h>
+#include CODEGEN_COMPONENT_DESCRIPTOR_H
+
+namespace facebook {
+namespace react {
+
+void registerProviders() {
+    auto providerRegistry = CoreComponentsRegistry::sharedProviderRegistry();
+    providerRegistry->add(concreteComponentDescriptorProvider<LottieAnimationViewComponentDescriptor>());
+}
+
+}
+}
+
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
+    facebook::react::registerProviders();
+    return JNI_VERSION_1_6;
+}

--- a/packages/core/android/src/newarch/com/airbnb/android/react/lottie/LottieAnimationViewManager.kt
+++ b/packages/core/android/src/newarch/com/airbnb/android/react/lottie/LottieAnimationViewManager.kt
@@ -26,12 +26,21 @@ import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.LottieAnimationViewManagerDelegate
 import com.facebook.react.viewmanagers.LottieAnimationViewManagerInterface
+import com.facebook.soloader.SoLoader
 import java.util.*
 
 @ReactModule(name = LottieAnimationViewManagerImpl.REACT_CLASS)
 class LottieAnimationViewManager :
     SimpleViewManager<LottieAnimationView>(),
     LottieAnimationViewManagerInterface<LottieAnimationView> {
+    companion object {
+        init {
+            if (BuildConfig.CODEGEN_MODULE_REGISTRATION != null) {
+                SoLoader.loadLibrary(BuildConfig.CODEGEN_MODULE_REGISTRATION)
+            }
+        }
+    }
+
     private val propManagersMap =
         WeakHashMap<LottieAnimationView, LottieAnimationViewPropertyManager>()
     private val delegate: ViewManagerDelegate<LottieAnimationView>


### PR DESCRIPTION
# Background

Support for Fabric on 0.68/0.69 requires manual registration inside custom `RNScreensComponentsRegistry`, according to [Introducing Fabric to react-native-screens](https://blog.swmansion.com/introducing-fabric-to-react-native-screens-fd17bf18858e), especially [Android base changes](https://github.com/software-mansion/react-native-screens/pull/1263)

# Solution

Backport `lottie-react-native` to 0.68/0.69 as https://github.com/callstack/react-native-builder-bob/pull/360

# Test Plan

Tested on `fabric-compat` example: https://github.com/Sunbreak/lottie-react-native/tree/compat-example