### PR TITLE
export types from lottie

### DIFF
--- a/apps/paper/src/LottieAnimatedExample.tsx
+++ b/apps/paper/src/LottieAnimatedExample.tsx
@@ -1,6 +1,5 @@
 import Slider from '@react-native-community/slider';
-import LottieView from 'lottie-react-native';
-import {LottieViewProps} from 'lottie-react-native/lib/typescript/LottieView.types';
+import LottieView, {LottieViewProps} from 'lottie-react-native';
 import React, {useEffect, useRef, useState} from 'react';
 import {
   Animated,

--- a/apps/paper/src/RenderModePicker.tsx
+++ b/apps/paper/src/RenderModePicker.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from 'react';
 import {Platform} from 'react-native';
 import DropDownPicker from 'react-native-dropdown-picker';
-import {LottieViewProps} from 'lottie-react-native/lib/typescript/LottieView.types';
+import {LottieViewProps} from 'lottie-react-native';
 
 interface Props {
   renderMode: LottieViewProps['renderMode'];

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -1,3 +1,3 @@
 import { LottieView } from './LottieView';
-export * from './LottieView.types.ts'
+export * from './LottieView.types'
 export default LottieView;

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -1,2 +1,3 @@
 import { LottieView } from './LottieView';
+export * from './LottieView.types.ts'
 export default LottieView;


### PR DESCRIPTION
version 6.0.0 removed the types from lottie. this change should allow them to be imported again

```ts
src/apps/Focus/screens/Landing/index.tsx:1:23 - error TS2614: Module '"lottie-react-native"' has no exported member 'AnimationObject'. Did you mean to use 'import AnimationObject from "lottie-react-native"' instead?

1 import Lottie, { type AnimationObject } from 'lottie-react-native';
                        ~~~~~~~~~~~~~~~

```