### PR TITLE
fix: flickering in dot lottie for Android in Release Mode

### DIFF
--- a/packages/core/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.kt
+++ b/packages/core/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.kt
@@ -116,6 +116,7 @@ class LottieAnimationViewPropertyManager(view: LottieAnimationView) {
 
             view.setAnimation(resourceId)
             animationNameDirty = false
+            sourceDotLottie = null
         }
 
         if (animationNameDirty) {


### PR DESCRIPTION
Related : #1091 

Using dotLottie animation as a `progress` property with an animated value, like in the code below, causes severe flickering in release mode.

```js
const AnimatedLottieView = Animated.createAnimatedComponent(LottieView);

export default function ControllingAnimationProgress() {
  const animationProgress = useRef(new Animated.Value(0));

  useEffect(() => {
    Animated.timing(animationProgress.current, {
      toValue: 1,
      duration: 5000,
      easing: Easing.linear,
      useNativeDriver: false,
    }).start();
  }, []);

  return (
    <AnimatedLottieView
      source={require("../path/to/animation.lottie")}
      progress={animationProgress.current}
    />
  );
}
```
