### PR TITLE
chore: check uri scheme instead of BuildConfig.DEBUG

### DIFF
--- a/packages/core/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.kt
+++ b/packages/core/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.kt
@@ -96,7 +96,9 @@ class LottieAnimationViewPropertyManager(view: LottieAnimationView) {
         }
 
         sourceDotLottie?.let { assetName ->
-            if(BuildConfig.DEBUG) {
+            val scheme = runCatching { Uri.parse(assetName).scheme }.getOrNull()
+
+            if (scheme != null) {
                 view.setAnimationFromUrl(assetName)
                 sourceDotLottie = null
                 return


### PR DESCRIPTION
#1091 added code that (AFAICT) assumes debug builds will always load from Metro. However, it is possible to build a debuggable app that includes the JS bundle (although probably uncommon). Instead, I propose following the same approach as [ImageSource](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ImageSource.java#L78) which handles all possible inputs (remote uri, local asset, uri, local asset name, etc).

