### PR TITLE
fix(web): don't require @dotlottie/react-player to be installed for JSON animations

### DIFF
--- a/packages/core/src/LottieView/index.web.tsx
+++ b/packages/core/src/LottieView/index.web.tsx
@@ -5,6 +5,8 @@ import { parsePossibleSources } from './utils';
 let DotLottiePlayer, Player;
 try {
     DotLottiePlayer = require('@dotlottie/react-player').DotLottiePlayer;
+} catch (e) { }
+try {
     Player = require('@lottiefiles/react-lottie-player').Player;
 } catch (e) { }
 


### PR DESCRIPTION
The current web implementation requires projects to include both `@lottiefiles/react-lottie-player` and `@dotlottie/react-player` because they are required in the same try/catch block.

Apps should be able to install either of these depending on whether they need to play `.lottie` files or not.

This PR separates the requires into separate try/catch blocks so `@lottiefiles/react-lottie-player` can be installed and used without including `@dotlottie/react-player`.