### PR TITLE
feat(android): support font assets

### DIFF
--- a/packages/core/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.kt
+++ b/packages/core/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.kt
@@ -1,6 +1,7 @@
 package com.airbnb.android.react.lottie
 
 import android.graphics.ColorFilter
+import android.graphics.Typeface
 import android.net.Uri
 import android.util.Log
 import android.widget.ImageView
@@ -10,6 +11,7 @@ import com.airbnb.lottie.LottieProperty
 import com.airbnb.lottie.RenderMode
 import com.airbnb.lottie.SimpleColorFilter
 import com.airbnb.lottie.TextDelegate
+import com.airbnb.lottie.FontAssetDelegate
 import com.airbnb.lottie.model.KeyPath
 import com.airbnb.lottie.value.LottieValueCallback
 import com.facebook.react.BuildConfig
@@ -17,6 +19,8 @@ import com.facebook.react.bridge.ColorPropConverter
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReadableType
+import com.facebook.react.views.text.ReactFontManager
+import com.facebook.react.views.text.TextAttributeProps.UNSET
 import com.facebook.react.util.RNLog
 import java.lang.ref.WeakReference
 import java.util.regex.Pattern
@@ -60,6 +64,29 @@ class LottieAnimationViewPropertyManager(view: LottieAnimationView) {
 
     init {
         viewWeakReference = WeakReference(view)
+
+        view.setFontAssetDelegate(object : FontAssetDelegate() {
+            override fun fetchFont(fontFamily: String): Typeface {
+                val typeface = ReactFontManager.getInstance()
+                    .getTypeface(fontFamily, UNSET, UNSET, view.context.assets)
+                return typeface?: Typeface.defaultFromStyle(400)
+            }
+        
+            override fun fetchFont(fontFamily: String, fontStyle: String, fontName: String): Typeface {
+                val weight = when (fontStyle) {
+                    "Thin" -> 100
+                    "Light" -> 200
+                    "Normal", "Regular" -> 400
+                    "Medium" -> 500
+                    "Bold" -> 700
+                    "Black" -> 900
+                    else -> UNSET
+                }
+                val typeface = ReactFontManager.getInstance()
+                    .getTypeface(fontName, UNSET, weight, view.context.assets)
+                return typeface?: Typeface.defaultFromStyle(400)
+            }
+        })
     }
 
     /**


### PR DESCRIPTION
Lottie Android v6 includes feature https://github.com/airbnb/lottie-android/pull/2103 so we can use ReactFontManager to get loaded font assets correctly.

For example, https://lottiefiles.com/animations/3d-loop-button-with-text-change-option-mbnBq8lzk2 will caused app crash during error `Font asset not found fonts/Roboto.ttf`.

This PR:
- If found the font, it should displayed text correctly
- It can avoid the app crash with default typeface fallback if font asset not found

I've been using this patch internally from lottie-react-native v5 (it was Java version) some time. It also fix #961.

For iOS, it should be supported by default.