### PR TITLE
fix(ios): missing configuration if textFilters used

### DIFF
--- a/packages/core/ios/LottieReactNative/ContainerView.swift
+++ b/packages/core/ios/LottieReactNative/ContainerView.swift
@@ -103,9 +103,11 @@ class ContainerView: RCTView {
                 filters[key] = value
             }
 
-            let nextAnimationView = LottieAnimationView()
+            let nextAnimationView = LottieAnimationView(
+                animation: animationView?.animation,
+                configuration: lottieConfiguration
+            )
             nextAnimationView.textProvider = DictionaryTextProvider(filters)
-            nextAnimationView.animation = animationView?.animation
             replaceAnimationView(next: nextAnimationView)
         }
     }


### PR DESCRIPTION
So we can choose to use mainThread or coreAnimation when using text filters.