### PR TITLE
chore(iOS): Use `install_modules_dependencies` in Podspec

### DIFF
--- a/packages/core/ios/Fabric/LottieAnimationViewComponentView.mm
+++ b/packages/core/ios/Fabric/LottieAnimationViewComponentView.mm
@@ -19,18 +19,22 @@ using namespace facebook::react;
     LottieContainerView *_view;
 }
 
++(void) load {
+    [super load];
+}
+
 - (instancetype) initWithFrame:(CGRect)frame
 {
     if (self = [super initWithFrame:frame]) {
         static const auto defaultProps = std::make_shared<const LottieAnimationViewProps>();
         _props = defaultProps;
-        
+
         _view = [LottieContainerView new];
         _view.delegate = self;
-        
+
         self.contentView = _view;
     }
-    
+
     return self;
 }
 
@@ -44,55 +48,55 @@ using namespace facebook::react;
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps {
     const auto &oldLottieProps = *std::static_pointer_cast<const LottieAnimationViewProps>(_props);
     const auto &newLottieProps = *std::static_pointer_cast<const LottieAnimationViewProps>(props);
-    
+
     if(oldLottieProps.resizeMode != newLottieProps.resizeMode) {
         [_view setResizeMode:RCTNSStringFromString(newLottieProps.resizeMode)];
     }
-    
+
     if(oldLottieProps.sourceJson != newLottieProps.sourceJson) {
         [_view setSourceJson:RCTNSStringFromString(newLottieProps.sourceJson.c_str())];
     }
-    
+
     if(oldLottieProps.sourceDotLottieURI != newLottieProps.sourceDotLottieURI) {
         [_view setSourceDotLottieURI:RCTNSStringFromString(newLottieProps.sourceDotLottieURI)];
     }
-    
+
     if(oldLottieProps.sourceName != newLottieProps.sourceName) {
         [_view setSourceName:RCTNSStringFromString(newLottieProps.sourceName)];
     }
-    
+
     if(oldLottieProps.sourceURL != newLottieProps.sourceURL) {
         [_view setSourceURL:RCTNSStringFromString(newLottieProps.sourceURL)];
     }
-    
+
     if(oldLottieProps.progress != newLottieProps.progress) {
         [_view setProgress:newLottieProps.progress];
     }
-    
+
     if(oldLottieProps.loop != newLottieProps.loop) {
         [_view setLoop:newLottieProps.loop];
     }
-    
+
     if(oldLottieProps.speed != newLottieProps.speed) {
         [_view setSpeed:newLottieProps.speed];
     }
-    
+
     if(oldLottieProps.colorFilters != newLottieProps.colorFilters) {
         [_view setColorFilters:convertColorFilters(newLottieProps.colorFilters)];
     }
-    
+
     if(oldLottieProps.textFiltersIOS != newLottieProps.textFiltersIOS) {
         [_view setTextFiltersIOS:convertTextFilters(newLottieProps.textFiltersIOS)];
     }
-    
+
     if(oldLottieProps.renderMode != newLottieProps.renderMode) {
         [_view setRenderMode:RCTNSStringFromString(newLottieProps.renderMode)];
     }
-    
+
     if(oldLottieProps.autoPlay != newLottieProps.autoPlay) {
         [_view setAutoPlay:newLottieProps.autoPlay];
     }
-    
+
     [super updateProps:props oldProps:oldProps];
 }
 
@@ -132,11 +136,11 @@ using namespace facebook::react;
     if(!_eventEmitter) {
         return;
     }
-    
+
     LottieAnimationViewEventEmitter::OnAnimationFinish event = {
         .isCancelled = isCancelled
     };
-    
+
     std::dynamic_pointer_cast<const LottieAnimationViewEventEmitter>(_eventEmitter)->onAnimationFinish(event);
 }
 
@@ -145,11 +149,11 @@ using namespace facebook::react;
     if(!_eventEmitter) {
         return;
     }
-    
+
     LottieAnimationViewEventEmitter::OnAnimationFailure event = {
         .error = std::string([error UTF8String])
     };
-    
+
     std::dynamic_pointer_cast<const LottieAnimationViewEventEmitter>(_eventEmitter)->onAnimationFailure(event);
 }
 

--- a/packages/core/lottie-react-native.podspec
+++ b/packages/core/lottie-react-native.podspec
@@ -2,8 +2,6 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
-
 Pod::Spec.new do |s|
   s.name                    = package["name"]
   s.version                 = package['version']
@@ -21,26 +19,35 @@ Pod::Spec.new do |s|
   s.source_files            = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency 'lottie-ios', '~> 4.3.3'
-  
+
   s.swift_version = '5.6'
 
-  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-      "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-      "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
-      "DEFINES_MODULE" => "YES",
-    }
-    
-    s.dependency "React-RCTFabric"
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
+  # install_modules_dependencies has been defined since React Native 70
+  # if you only support React Native 70+, we can remove the `if defined?() else` statement
+  if defined?(install_modules_dependencies)
+    install_modules_dependencies(s)
+    if !(ENV['RCT_NEW_ARCH_ENABLED'] == '1') then
+      s.exclude_files = "ios/Fabric"
+    end
   else
-    s.dependency 'React-Core'
-    s.exclude_files = "ios/Fabric"
+    if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
+      s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
+      s.pod_target_xcconfig    = {
+        "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
+        "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+        "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
+        "DEFINES_MODULE" => "YES",
+      }
+
+      s.dependency "React-RCTFabric"
+      s.dependency "React-Codegen"
+      s.dependency "RCT-Folly"
+      s.dependency "RCTRequired"
+      s.dependency "RCTTypeSafety"
+      s.dependency "ReactCommon/turbomodule/core"
+    else
+      s.dependency 'React-Core'
+      s.exclude_files = "ios/Fabric"
+    end
   end
 end

--- a/packages/core/lottie-react-native.podspec
+++ b/packages/core/lottie-react-native.podspec
@@ -31,6 +31,7 @@ Pod::Spec.new do |s|
     end
   else
     if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
+      folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
       s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
       s.pod_target_xcconfig    = {
         "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",


### PR DESCRIPTION
This change updates the `lottie-react-native.podspec` to consume the `install_modules_dependencies` function provided by React Native to configure the pods dependencies.
Thanks to using this function, whenever we update the pods structure in React Native, the library will automatically benefit from it.
This will make the library more future proof and more resilient to changes in React Native.

This allow Lottie to work also with `use_frameworks!` and with the New Architecture. Before the change, it failed to build when `use_frameworks!` was set in RN 0.73.x

## Test plan

Tested locally:

Before changes
1. Created a new app with `npx react-native init RNFrameworks --version
latest --skip-install`
1. `cd RNFrameworks`
1. `yarn add lottie-react-native`
1. `yarn install`
1. `cd ios`
1. `NO_FLIPPER=1 USE_FRAMEWORKS=dynamic RCT_NEW_ARCH_ENABLED=1 bundle
exec pod install`
1. `open RNFrameworks`
1. build and run and observe it failing

Apply the changes to local node_modules's `lottie-react-native.podspec` changes
1. Reinstall pods `NO_FLIPPER=1 USE_FRAMEWORKS=dynamic
RCT_NEW_ARCH_ENABLED=1 bundle exec pod install`
1. `open RNFrameworks`
1. build and run and observe it succeeding


Fixes: #1067, #1138