### PR TITLE
fix: animation frames being incorrect on new arch for the first frame

### DIFF
--- a/packages/core/ios/LottieReactNative/ContainerView.swift
+++ b/packages/core/ios/LottieReactNative/ContainerView.swift
@@ -287,10 +287,9 @@ class ContainerView: RCTView {
     }
 
     // The animation view is a child of the RCTView, so if the bounds ever change, add those changes to the animation view as well
-    override var bounds: CGRect {
-        didSet {
-            animationView?.frame = self.bounds
-        }
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        animationView?.frame = self.bounds
     }
 
     // MARK: Private


### PR DESCRIPTION
The frame of the child animation view on iOS is not setup or updated correctly when we first render the element. This has been due to us reading the `bounds` from `RCTView`, which for some reason is reporting incorrect values on the new arch on initial render. This PR switches us over to overriding and calling `layoutSubiews` directly, which lets us correctly set the frame.

I have tested this on both Fabric and on Paper to make sure nothing has broken for any of the implementations