### PR TITLE
fix(workaround): enable `install_modules_dependencies` just for RN 73 and above

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll": true,
-    "source.fixAll.eslint": true
+    "source.fixAll": "explicit",
+    "source.fixAll.eslint": "explicit"
   },
   "editor.formatOnSave": true,
   "javascript.format.enable": false

--- a/apps/fabric/ios/Podfile.lock
+++ b/apps/fabric/ios/Podfile.lock
@@ -1445,7 +1445,7 @@ SPEC CHECKSUMS:
   React-utils: debda2c206770ee2785bdebb7f16d8db9f18838a
   ReactCommon: ddb128564dcbfa0287d3d1a2d10f8c7457c971f6
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  Yoga: 2b33a7ac96c58cdaa7b810948fc6a2a76ed2d108
+  Yoga: 4f53dc50008d626fa679c7a1cb4bed898f8c0bde
 
 PODFILE CHECKSUM: 40287ce1aaf5414bc3bea07749a9018d1c25c132
 

--- a/apps/fabric/ios/example/Info.plist
+++ b/apps/fabric/ios/example/Info.plist
@@ -26,7 +26,6 @@
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-	    <!-- Do not change NSAllowsArbitraryLoads to true, or you will risk app rejection! -->
 		<key>NSAllowsArbitraryLoads</key>
 		<false/>
 		<key>NSAllowsLocalNetworking</key>

--- a/packages/core/lottie-react-native.podspec
+++ b/packages/core/lottie-react-native.podspec
@@ -2,6 +2,11 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
+# TODO(workaround): We need to replace this line with   if defined?(install_modules_dependencies)
+react_package_file = File.expand_path("../react-native/package.json", File.dirname(__FILE__))
+react_package = JSON.parse(File.read(react_package_file))
+minor_react_version = react_package['version'].split('.')[1].to_i
+
 Pod::Spec.new do |s|
   s.name                    = package["name"]
   s.version                 = package['version']
@@ -24,7 +29,9 @@ Pod::Spec.new do |s|
 
   # install_modules_dependencies has been defined since React Native 70
   # if you only support React Native 70+, we can remove the `if defined?() else` statement
-  if defined?(install_modules_dependencies)
+  # TODO: checking RN version for backward comaptibility reasons since lottie is not compatible with RN 72 and below with install_modules_dependencies
+  # TODO: We need to replace this line with   if defined?(install_modules_dependencies)
+  if minor_react_version >= 73
     install_modules_dependencies(s)
     if !(ENV['RCT_NEW_ARCH_ENABLED'] == '1') then
       s.exclude_files = "ios/Fabric"

--- a/packages/core/lottie-react-native.podspec
+++ b/packages/core/lottie-react-native.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-# TODO(workaround): We need to replace this line with   if defined?(install_modules_dependencies)
+# Read the React Native version from the package.json relative to the podspec file
 react_package_file = File.expand_path("../react-native/package.json", File.dirname(__FILE__))
 react_package = JSON.parse(File.read(react_package_file))
 minor_react_version = react_package['version'].split('.')[1].to_i
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
 
   # install_modules_dependencies has been defined since React Native 70
   # if you only support React Native 70+, we can remove the `if defined?() else` statement
-  # TODO: checking RN version for backward comaptibility reasons since lottie is not compatible with RN 72 and below with install_modules_dependencies
+  # TODO(workaround): checking RN version for backward comaptibility reasons since lottie is not compatible with RN 72 and below with install_modules_dependencies
   # TODO: We need to replace this line with   if defined?(install_modules_dependencies)
   if minor_react_version >= 73
     install_modules_dependencies(s)

--- a/packages/core/lottie-react-native.podspec
+++ b/packages/core/lottie-react-native.podspec
@@ -39,13 +39,13 @@ Pod::Spec.new do |s|
   # TODO(workaround): checking RN version for backward comaptibility reasons since lottie is not compatible with RN 72 and below with install_modules_dependencies
   # TODO: We need to replace this line with   if defined?(install_modules_dependencies)
   if is_install_modules_dependencies_needed then
-    print "Using install_modules_dependencies\n"
+    Pod::UI.puts("[Lottie React Native] Using install_modules_dependencies")
     install_modules_dependencies(s)
     if !(ENV['RCT_NEW_ARCH_ENABLED'] == '1') then
       s.exclude_files = "ios/Fabric"
     end
   else
-    print "Not using install_modules_dependencies\n"
+    Pod::UI.puts("[Lottie React Native] Installing manually")
     if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
       folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
       s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"

--- a/packages/core/lottie-react-native.podspec
+++ b/packages/core/lottie-react-native.podspec
@@ -2,10 +2,17 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
-# Read the React Native version from the package.json relative to the podspec file
-react_package_file = File.expand_path("../react-native/package.json", File.dirname(__FILE__))
-react_package = JSON.parse(File.read(react_package_file))
-minor_react_version = react_package['version'].split('.')[1].to_i
+def self.is_install_modules_dependencies_needed
+  begin
+    # Read the React Native version from the package.json relative to the podspec file
+    react_package_file = File.expand_path("../react-native/package.json", File.dirname(__FILE__))
+    react_package = JSON.parse(File.read(react_package_file))
+    minor_react_version = react_package['version'].split('.')[1].to_i
+    return minor_react_version >= 73 && defined?(install_modules_dependencies)
+  rescue
+    return true
+  end
+end
 
 Pod::Spec.new do |s|
   s.name                    = package["name"]
@@ -31,12 +38,14 @@ Pod::Spec.new do |s|
   # if you only support React Native 70+, we can remove the `if defined?() else` statement
   # TODO(workaround): checking RN version for backward comaptibility reasons since lottie is not compatible with RN 72 and below with install_modules_dependencies
   # TODO: We need to replace this line with   if defined?(install_modules_dependencies)
-  if minor_react_version >= 73
+  if is_install_modules_dependencies_needed then
+    print "Using install_modules_dependencies\n"
     install_modules_dependencies(s)
     if !(ENV['RCT_NEW_ARCH_ENABLED'] == '1') then
       s.exclude_files = "ios/Fabric"
     end
   else
+    print "Not using install_modules_dependencies\n"
     if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
       folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
       s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"


### PR DESCRIPTION
`install_modules_dependencies` is not working as expected with `RCT_NEW_ARCH_ENABLED=1` for some reason. This is a temporary fix for 72 and below to ensure backward compatibility.