### PR TITLE
fix: remove incorrect typeface default

### DIFF
--- a/packages/core/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.kt
+++ b/packages/core/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.kt
@@ -3,7 +3,6 @@ package com.airbnb.android.react.lottie
 import android.graphics.ColorFilter
 import android.graphics.Typeface
 import android.net.Uri
-import android.util.Log
 import android.widget.ImageView
 import com.airbnb.lottie.LottieAnimationView
 import com.airbnb.lottie.LottieDrawable
@@ -14,7 +13,6 @@ import com.airbnb.lottie.TextDelegate
 import com.airbnb.lottie.FontAssetDelegate
 import com.airbnb.lottie.model.KeyPath
 import com.airbnb.lottie.value.LottieValueCallback
-import com.facebook.react.BuildConfig
 import com.facebook.react.bridge.ColorPropConverter
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
@@ -70,9 +68,8 @@ class LottieAnimationViewPropertyManager(view: LottieAnimationView) {
 
         view.setFontAssetDelegate(object : FontAssetDelegate() {
             override fun fetchFont(fontFamily: String): Typeface {
-                val typeface = ReactFontManager.getInstance()
+                return ReactFontManager.getInstance()
                     .getTypeface(fontFamily, UNSET, UNSET, view.context.assets)
-                return typeface?: Typeface.defaultFromStyle(400)
             }
         
             override fun fetchFont(fontFamily: String, fontStyle: String, fontName: String): Typeface {
@@ -85,9 +82,8 @@ class LottieAnimationViewPropertyManager(view: LottieAnimationView) {
                     "Black" -> 900
                     else -> UNSET
                 }
-                val typeface = ReactFontManager.getInstance()
+                return ReactFontManager.getInstance()
                     .getTypeface(fontName, UNSET, weight, view.context.assets)
-                return typeface?: Typeface.defaultFromStyle(400)
             }
         })
     }


### PR DESCRIPTION
Introduced in https://github.com/lottie-react-native/lottie-react-native/pull/1128, this PR aims to remove the incorrect default that was being set for the type face. The value `400` is not a valid type face, and strictly not required in this context as `getTypeface` always returns a valid type face.

Note for the future: This variant of `ReactFontManager` is now depracated. RN 73 introduces a new package: `com.facebook.react.common.assets.ReactFontManager`. We should consider doing a breaking change at some point to cover both this and the updated podspec build script.

<img width="1839" alt="Screenshot 2024-01-04 at 15 46 08" src="https://github.com/lottie-react-native/lottie-react-native/assets/40071952/d650e184-7c54-4ddc-bada-3aa351b6cddd">
