### PR TITLE
chore: add linting to paper's build step on Android

### DIFF
--- a/.github/workflows/android-paper-build.yml
+++ b/.github/workflows/android-paper-build.yml
@@ -49,6 +49,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Build Paper Android Example
+      - name: Build and Lint Paper Android Example
         run: |
-          yarn paper:build:android
+          yarn paper:lint:android && yarn paper:build:android

--- a/apps/paper/package.json
+++ b/apps/paper/package.json
@@ -6,6 +6,7 @@
     "reset": "watchman watch-del-all; rm -rf /tmp/metro-bundler-cache-*; rm -rf ./android/build; rm -rf ./android/.gradle; rm -rf ./android/app/build; rm -rf ~/Library/Developer/Xcode/DerivedData; rm -rf /tmp/haste-map-react-native-packager-*; rm -rf ./ios/build; jest --clearCache; cd ios; pod install --repo-update; cd ..; npx jetify; cd android; ./gradlew clean; cd ..;",
     "android": "react-native run-android",
     "build:android": "cd android && ./gradlew assembleDebug --no-daemon --console=plain -PreactNativeArchitectures=arm64-v8a",
+    "lint:android": "cd android && ./gradlew lottie-react-native:lint --no-daemon --console=plain && cd ..",
     "ios": "bundle install && pod install --project-directory=ios && react-native run-ios",
     "web": "webpack serve",
     "start": "react-native start",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "fabric:ios-dynamic-framework": "yarn workspace fabric-example ios-dynamic-framework",
     "paper:start:android": "yarn workspace paper-example android",
     "paper:build:android": "yarn workspace paper-example build:android",
+    "paper:lint:android": "yarn workspace paper-example lint:android",
     "paper:ios": "yarn workspace paper-example ios",
     "paper:web": "yarn workspace paper-example web",
     "lint:swift": "yarn workspace lottie-react-native lint:swift",


### PR DESCRIPTION
Add CI build step on Android to lint the Kotlin files before building to ensure stuff like https://github.com/lottie-react-native/lottie-react-native/issues/1150 never happens again