### PR TITLE
feat: add privacy manifest for iOS

### DIFF
--- a/packages/core/ios/PrivacyInfo.xcprivacy
+++ b/packages/core/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>

--- a/packages/core/lottie-react-native.podspec
+++ b/packages/core/lottie-react-native.podspec
@@ -29,8 +29,11 @@ Pod::Spec.new do |s|
 
   s.source                  = { :git => "https://github.com/lottie-react-native/lottie-react-native.git", :tag => "v#{s.version}" }
   s.source_files            = "ios/**/*.{h,m,mm,swift}"
+  s.resource_bundles = {
+    'Lottie_React_Native_Privacy' => ['ios/PrivacyInfo.xcprivacy'],
+  }
 
-  s.dependency 'lottie-ios', '~> 4.3.3'
+  s.dependency 'lottie-ios', '~> 4.3.4'
 
   s.swift_version = '5.6'
 


### PR DESCRIPTION
This PR aims to make us compliant with Apple's upcoming privacy manifest requirements that will go into effect come Spring 2024. We will need to do another update once [Lottie iOS releases 4.4.0](https://github.com/airbnb/lottie-ios/pull/2252#issuecomment-1885925359) with their own privacy manifest as well, but for now, This is all that is required.
I also bumped our Lottie iOS dep to 4.3.4, just so everything is on the latest version