### PR TITLE
chore: bump lottie ios version

### DIFF
--- a/.github/workflows/ios-paper-build.yml
+++ b/.github/workflows/ios-paper-build.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   build-example:
-    runs-on: macos-13-arm64
+    runs-on: macos-13
 
     strategy:
       matrix:

--- a/.github/workflows/ios-paper-build.yml
+++ b/.github/workflows/ios-paper-build.yml
@@ -12,11 +12,11 @@ concurrency:
 
 jobs:
   build-example:
-    runs-on: macos-12
+    runs-on: macos-13-arm64
 
     strategy:
       matrix:
-        xcode-version: [14.0, 14.3]
+        xcode-version: [14.2, 14.3.1]
 
     steps:
       - name: List all available XCode versions

--- a/.github/workflows/ios-paper-build.yml
+++ b/.github/workflows/ios-paper-build.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        xcode-version: [13.3.1, 14.2]
+        xcode-version: [14.0, 14.3]
 
     steps:
       - name: List all available XCode versions

--- a/apps/fabric/ios/Podfile.lock
+++ b/apps/fabric/ios/Podfile.lock
@@ -65,11 +65,11 @@ PODS:
     - hermes-engine/Pre-built (= 0.73.1)
   - hermes-engine/Pre-built (0.73.1)
   - libevent (2.1.12)
-  - lottie-ios (4.3.4)
+  - lottie-ios (4.4.0)
   - lottie-react-native (6.5.1):
     - glog
     - hermes-engine
-    - lottie-ios (~> 4.3.3)
+    - lottie-ios (~> 4.4.0)
     - RCT-Folly (= 2022.05.16.00)
     - RCTRequired
     - RCTTypeSafety
@@ -1396,8 +1396,8 @@ SPEC CHECKSUMS:
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: 34df9d5034e90bd9bf1505e1ca198760373935af
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  lottie-ios: 3d98679b41fa6fd6aff2352b3953dbd3df8a397e
-  lottie-react-native: 80bda323805fa62005afff0583d2927a89108f20
+  lottie-ios: ef1be1f90d54255f08e09d767950e43714661178
+  lottie-react-native: 1a59f200516f6df90011b987ae7d530455876bab
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
   RCTRequired: 6dda55e483f75d2b43781d8ad5bd7df276a50981

--- a/apps/paper/ios/Podfile.lock
+++ b/apps/paper/ios/Podfile.lock
@@ -74,9 +74,9 @@ PODS:
     - hermes-engine/Pre-built (= 0.72.6)
   - hermes-engine/Pre-built (0.72.6)
   - libevent (2.1.12)
-  - lottie-ios (4.3.4)
+  - lottie-ios (4.4.0)
   - lottie-react-native (6.5.1):
-    - lottie-ios (~> 4.3.3)
+    - lottie-ios (~> 4.4.0)
     - React-Core
   - OpenSSL-Universal (1.1.1100)
   - RCT-Folly (2021.07.22.00):
@@ -689,8 +689,8 @@ SPEC CHECKSUMS:
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: 8057e75cfc1437b178ac86c8654b24e7fead7f60
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  lottie-ios: 3d98679b41fa6fd6aff2352b3953dbd3df8a397e
-  lottie-react-native: cdeae481649c11d586084b8662f03251c4dd8249
+  lottie-ios: ef1be1f90d54255f08e09d767950e43714661178
+  lottie-react-native: c43a0dddb7c59eab1ff3c55a83a7aa2388881a80
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: 28469809442eb4eb5528462705f7d852948c8a74

--- a/packages/core/lottie-react-native.podspec
+++ b/packages/core/lottie-react-native.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
     'Lottie_React_Native_Privacy' => ['ios/PrivacyInfo.xcprivacy'],
   }
 
-  s.dependency 'lottie-ios', '~> 4.3.4'
+  s.dependency 'lottie-ios', '~> 4.4.0'
 
   s.swift_version = '5.6'
 

--- a/packages/core/lottie-react-native.podspec
+++ b/packages/core/lottie-react-native.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   s.homepage                = package["homepage"]
 
   s.ios.deployment_target   = '12.4'
-  s.osx.deployment_target   = '10.10'
+  s.osx.deployment_target   = '10.12'
   s.tvos.deployment_target  = '12.4'
 
   s.source                  = { :git => "https://github.com/lottie-react-native/lottie-react-native.git", :tag => "v#{s.version}" }

--- a/packages/core/lottie-react-native.podspec
+++ b/packages/core/lottie-react-native.podspec
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'lottie-ios', '~> 4.4.0'
 
-  s.swift_version = '5.6'
+  s.swift_version = '5.7'
 
   # install_modules_dependencies has been defined since React Native 70
   # if you only support React Native 70+, we can remove the `if defined?() else` statement


### PR DESCRIPTION
[Lottie iOS 4.4.0](https://github.com/airbnb/lottie-ios/pull/2252#issuecomment-1905052471) has been released. It includes the new privacy manifest file, and some other changes. I am bumping the package but i think since swift 5.6 is dropped, i would need to update the CI as well