### PR TITLE
[Windows]Add windows to lottie published files

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,8 @@
     "android",
     "ios",
     "*.podspec",
-    "react-native.config.js"
+    "react-native.config.js",
+    "windows"
   ],
   "author": "Emilio Rodriguez <emiliorodriguez@gmail.com>",
   "homepage": "https://github.com/airbnb/lottie-react-native#readme",


### PR DESCRIPTION
## Motivation
Looks like when moving over to v6 of the Lottie package it appears that the files were copied over to a new folder destination and there were changes to the `package.json` to limit the range of published files, unfortunately, it looks like these changes excluded the windows folder. So while [the files are present in the repo](https://github.com/lottie-react-native/lottie-react-native/tree/master/packages/core/windows), they are not published as part of the package, thus react native windows developers are effectively locked out of consuming the newer versions of this package.

## Solution
### Fixed
- Fixed missing windows directly in published files list in the package.json