### PR TITLE
feat: add issue triage bot

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,252 @@
+name: Issue Triage
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  needs-repro:
+    runs-on: ubuntu-22.04
+    if: "${{ contains(github.event.label.name, 'incomplete issue: missing or invalid repro') }}"
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Hi there! It looks like your issue requires a minimal reproducible example, but it is invalid or absent. Please prepare such an example and share it in a new issue.
+
+              **The best way to get attention to your issue is to provide a clean and easy way for a developer to reproduce the issue on their own machine.** Please do not provide your entire project, or a project with more code than is necessary to reproduce the issue.
+
+              A side benefit of going through the process of narrowing down the minimal amount of code needed to reproduce the issue is that you may get lucky and discover that the bug is due to a mistake in your application code that you can quickly fix on your own.
+
+              ### Resources
+
+              - ["How to create a Minimal, Reproducible Example"](https://stackoverflow.com/help/minimal-reproducible-example)
+              - ["How to narrow down the source of an error"](https://expo.fyi/manual-debugging)
+
+              ### Common concerns
+
+              #### "I've only been able to reproduce it in private, proprietary code"
+
+              You may not have spent enough time narrowing down the root cause of the issue. Try out the techniques discussed in this [manual debugging guide](https://expo.fyi/manual-debugging) to learn how to isolate the problem from the rest of your codebase.
+
+              #### "I didn't have time to create one"
+
+              That's understandable, it can take some time to prepare. We ask that you hold off on filing an issue until you are able to fully complete the required fields in the issue template.
+
+              #### "You can reproduce it by yourself by creating a project and following these steps"
+
+              This is useful knowledge, but it's still valuable to have the resulting project that is produced from running the steps, where you have verified you can reproduce the issue.
+            `})
+            github.rest.issues.update({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed'
+            })
+
+  needs-info:
+    runs-on: ubuntu-22.04
+    if: "${{ contains(github.event.label.name, 'incomplete issue: missing info') }}"
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Hello! There isn't enough information provided in your issue description for us to be able to help you. The best way to get help is to provide information to enable other developers to understand the issue and reproduce it on their own machines.
+
+              Please create a new issue and fill out the entire issue template to the best of your ability. Refer to the following resources for more information on how to create a good issue report.
+
+              ### Resources
+
+              - ["How do I ask a good question?"](https://stackoverflow.com/help/how-to-ask)
+              - ["How to create a Minimal, Reproducible Example"](https://stackoverflow.com/help/minimal-reproducible-example)
+              - ["How to narrow down the source of an error"](https://expo.fyi/manual-debugging)
+            `})
+            github.rest.issues.update({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed'
+            })
+
+  issue-accepted:
+    runs-on: ubuntu-22.04
+    permissions:
+      issues: write
+    if: github.event.label.name == 'issue accepted'
+    steps:
+      - name: Comment on issue
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Thank you for filing this issue!
+              This comment acknowledges we believe this may be a bug and there’s enough information to investigate it.
+              However, we can’t promise any sort of timeline for resolution. We prioritize issues based on severity, breadth of impact, and alignment with our roadmap. If you’d like to help move it more quickly, you can continue to investigate it more deeply and/or you can open a pull request that fixes the cause.
+            `})
+      - name: Remove "Needs Review" label
+        uses: actions/github-script@v6
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: ['needs review']
+              })
+            } catch (e) {
+              if (e.status != 404) {
+                throw e;
+              }
+            }
+      - name: 👀 Checkout
+        uses: actions/checkout@v4
+      - name: ➕ Add `bin` to GITHUB_PATH
+        run: echo "$(pwd)/bin" >> $GITHUB_PATH
+      - name: ♻️ Restore caches
+        uses: ./.github/actions/expo-caches
+        id: expo-caches
+        with:
+          yarn-tools: 'true'
+      - name: 🔎 Import issue to Linear
+        run: expotools import-github-issue-to-linear --issue "${{ github.event.issue.number }}" --importer "${{ github.triggering_actor }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+  question:
+    runs-on: ubuntu-22.04
+    if: "${{ contains(github.event.label.name, 'invalid issue: question') }}"
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Hello! Our GitHub issues are reserved for bug reports.
+
+              If you have a question about Expo or related tools, please post on our forums at https://forums.expo.dev/ or join our Discord at https://chat.expo.dev/.
+
+              ### Resources
+
+              - ["How do I ask a good question?"](https://stackoverflow.com/help/how-to-ask)
+              - ["Join the community"](https://docs.expo.dev/next-steps/community/)
+            `})
+            github.rest.issues.update({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed'
+            })
+
+  feature-request:
+    runs-on: ubuntu-22.04
+    if: "${{ contains(github.event.label.name, 'invalid issue: feature request') }}"
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Hello! Our GitHub issues are reserved for bug reports.
+
+              If you would like to request a feature, please post to https://expo.canny.io/feature-requests.
+            `})
+            github.rest.issues.update({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed'
+            })
+
+  third-party:
+    runs-on: ubuntu-22.04
+    if: "${{ contains(github.event.label.name, 'invalid issue: third-party library') }}"
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Hi there! It looks like your issue is more closely related to a third-party tool.
+
+              If you are able to narrow down the root cause to a bug relevant to this repository, please create an issue here with a [minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example). Otherwise, we recommend posting this issue to the repository for the tool that you are using.
+
+              ### Resources
+
+              - ["How to create a Minimal, Reproducible Example"](https://stackoverflow.com/help/minimal-reproducible-example)
+              - ["How to narrow down the source of an error"](https://expo.fyi/manual-debugging)
+            `})
+            github.rest.issues.update({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed'
+            })
+  react-native-core:
+    runs-on: ubuntu-22.04
+    if: "${{ contains(github.event.label.name, 'invalid issue: react-native-core') }}"
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Hi there! It looks like your issue concerns code in react-native core, rather than Expo tools.
+
+              We recommend posting this issue directly to the [react-native repository](https://github.com/facebook/react-native/issues/new/choose).
+            `})
+            github.rest.issues.update({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed'
+            })
+  comments-on-closed:
+    runs-on: ubuntu-22.04
+    if: "${{ github.event.label.name == 'Comments on closed issue' }}"
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Hi there! It looks you are commenting on an issue that has been marked as resolved.
+
+              If you are still experiencing this problem or a related one, please [open a new issue](https://github.com/expo/expo/issues/new/choose) and fill out the issue template.
+            `})
+            github.rest.issues.lock({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              lock_reason: 'resolved'
+            })


### PR DESCRIPTION
This PR aims to introduce a bot for ensuring that the issue template is followed by the person who opened the issue, so that the debugging process becomes less painful for both the maintainers and the people opening issues. The original workflow file is from Expo (Shout out to Brent from the Expo team). We will need to modify it to fit our needs, so i am putting it in draft mode until it is ready