### PR TITLE
refactor(web): replace inline require with import

### DIFF
--- a/packages/core/src/LottieView/index.web.tsx
+++ b/packages/core/src/LottieView/index.web.tsx
@@ -7,18 +7,11 @@ import React, {
 } from "react";
 import { parsePossibleSources } from "./utils";
 import { LottieViewProps } from "lottie-react-native";
-import type {
+import {
   DotLottieCommonPlayer,
+  DotLottiePlayer,
   PlayerEvents,
-  Props,
 } from "@dotlottie/react-player";
-
-let DotLottiePlayer: React.ForwardRefExoticComponent<
-  Props & React.RefAttributes<DotLottieCommonPlayer | null>
->;
-try {
-  DotLottiePlayer = require("@dotlottie/react-player").DotLottiePlayer;
-} catch (e) {}
 
 const LottieView = forwardRef(
   (
@@ -64,11 +57,11 @@ const LottieView = forwardRef(
       (fn: () => void) => {
         if (!isReady) {
           const container = playerRef.current?.container;
-          const listerner = () => {
+          const listener = () => {
             fn();
-            container?.removeEventListener("is_ready", listerner);
+            container?.removeEventListener("is_ready", listener);
           };
-          container?.addEventListener("is_ready", listerner);
+          container?.addEventListener("is_ready", listener);
         } else {
           fn();
         }
@@ -161,11 +154,6 @@ const LottieView = forwardRef(
       [isReady]
     );
 
-    if (!DotLottiePlayer) {
-      throw new Error(
-        "lottie-react-native: The module @dotlottie/react-player is missing."
-      );
-    }
     return (
       <DotLottiePlayer
         key={key}


### PR DESCRIPTION
### Why

The inline require is no longer necessary now that the web implementation always uses `@dotlottie/react-player`.

Replacing it with an import simplifies typing in the file and surfaces dependency issues at compile-time.

### Testing Notes

- ran the `setup` and `paper:web` scripts after making the change and verified that the example app still works

![image](https://github.com/lottie-react-native/lottie-react-native/assets/16565387/871870bb-1f72-4ff6-a9d9-1d02852fc648)