### PR TITLE
fix: pin lottie ios version in pod spec

### DIFF
--- a/apps/fabric/ios/Podfile.lock
+++ b/apps/fabric/ios/Podfile.lock
@@ -69,7 +69,7 @@ PODS:
   - lottie-react-native (6.7.0):
     - glog
     - hermes-engine
-    - lottie-ios (~> 4.4.1)
+    - lottie-ios (= 4.4.1)
     - RCT-Folly (= 2022.05.16.00)
     - RCTRequired
     - RCTTypeSafety
@@ -1397,7 +1397,7 @@ SPEC CHECKSUMS:
   hermes-engine: 1d1835b2cc54c381909d94d1b3c8e0a2f1a94a0e
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   lottie-ios: e047b1d2e6239b787cc5e9755b988869cf190494
-  lottie-react-native: e3812afa070c29ce6a22e0b5ef4c41f7ce1e8582
+  lottie-react-native: b00230ef2f16e7c35ae741b0074f3bec8da9bbb9
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
   RCTRequired: 2544c0f1081a5fa12e108bb8cb40e5f4581ccd87
@@ -1445,8 +1445,8 @@ SPEC CHECKSUMS:
   React-utils: 987a4526a2fc0acdfaf87888adfe0bf9d0452066
   ReactCommon: 2947b0bffd82ea0e58ca7928881152d4c6dae9af
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  Yoga: 9e6a04eacbd94f97d94577017e9f23b3ab41cf6c
+  Yoga: a716eea57d0d3430219c0a5a233e1e93ee931eb7
 
 PODFILE CHECKSUM: 40287ce1aaf5414bc3bea07749a9018d1c25c132
 
-COCOAPODS: 1.14.0
+COCOAPODS: 1.14.3

--- a/apps/paper/ios/Podfile.lock
+++ b/apps/paper/ios/Podfile.lock
@@ -76,7 +76,7 @@ PODS:
   - libevent (2.1.12)
   - lottie-ios (4.4.1)
   - lottie-react-native (6.7.0):
-    - lottie-ios (~> 4.4.1)
+    - lottie-ios (= 4.4.1)
     - React-Core
   - OpenSSL-Universal (1.1.1100)
   - RCT-Folly (2021.07.22.00):
@@ -689,7 +689,7 @@ SPEC CHECKSUMS:
   hermes-engine: 90e4033deb00bee33330a9f15eff0f874bd82f6d
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   lottie-ios: e047b1d2e6239b787cc5e9755b988869cf190494
-  lottie-react-native: e3205322282d72e23efb3bff3287d0bd16fb1b01
+  lottie-react-native: c0cd88c1a188323f7f677af22c0fc1fd49be78c9
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: b4d3068afa6f52ec5260a8417053b1f1b421483d

--- a/packages/core/lottie-react-native.podspec
+++ b/packages/core/lottie-react-native.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
     'Lottie_React_Native_Privacy' => ['ios/PrivacyInfo.xcprivacy'],
   }
 
-  s.dependency 'lottie-ios', '~> 4.4.1'
+  s.dependency 'lottie-ios', '4.4.1'
 
   s.swift_version = '5.7'
 


### PR DESCRIPTION
Pin Pod spec version for iOS, due to Lottie-iOS 4.4.2 having a iOS 13 requirement (Which is not fully supported in all RN versions, only since 0.73) We will drop support for it once we decide the minimum RN support should be 0.73