### PR TITLE
fix: DirectEvent to BubblingEvent on Android/Windows

### DIFF
--- a/packages/core/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManagerImpl.kt
+++ b/packages/core/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManagerImpl.kt
@@ -68,7 +68,7 @@ internal object LottieAnimationViewManagerImpl {
     }
 
     @JvmStatic
-    fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
+    fun getExportedCustomBubblingEventTypeConstants(): MutableMap<String, Any> {
         return MapBuilder.of(
             OnAnimationFinishEvent.EVENT_NAME,
             MapBuilder.of("registrationName", "onAnimationFinish"),

--- a/packages/core/android/src/newarch/com/airbnb/android/react/lottie/LottieAnimationViewManager.kt
+++ b/packages/core/android/src/newarch/com/airbnb/android/react/lottie/LottieAnimationViewManager.kt
@@ -89,8 +89,8 @@ class LottieAnimationViewManager :
         return view
     }
 
-    override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any>? {
-        return LottieAnimationViewManagerImpl.getExportedCustomDirectEventTypeConstants()
+    override fun getExportedCustomBubblingEventTypeConstants(): MutableMap<String, Any>? {
+        return LottieAnimationViewManagerImpl.getExportedCustomBubblingEventTypeConstants()
     }
 
     override fun onAfterUpdateTransaction(view: LottieAnimationView) {

--- a/packages/core/android/src/oldarch/com/airbnb/android/react/lottie/LottieAnimationViewManager.kt
+++ b/packages/core/android/src/oldarch/com/airbnb/android/react/lottie/LottieAnimationViewManager.kt
@@ -80,8 +80,8 @@ class LottieAnimationViewManager : SimpleViewManager<LottieAnimationView>() {
         return view
     }
 
-    override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any>? {
-        return LottieAnimationViewManagerImpl.getExportedCustomDirectEventTypeConstants()
+    override fun getExportedCustomBubblingEventTypeConstants(): MutableMap<String, Any>? {
+        return LottieAnimationViewManagerImpl.getExportedCustomBubblingEventTypeConstants()
     }
 
     override fun receiveCommand(

--- a/packages/core/windows/cppwinrt/LottieAnimationViewManager.cpp
+++ b/packages/core/windows/cppwinrt/LottieAnimationViewManager.cpp
@@ -197,14 +197,14 @@ namespace winrt::LottieReactNative::implementation {
     // IViewManagerWithExportedEventTypeConstants
     winrt::Microsoft::ReactNative::ConstantProviderDelegate LottieAnimationViewManager::ExportedCustomBubblingEventTypeConstants() noexcept
     {
-        return nullptr;
-    }
-
-    winrt::Microsoft::ReactNative::ConstantProviderDelegate LottieAnimationViewManager::ExportedCustomDirectEventTypeConstants() noexcept
-    {
         return [](IJSValueWriter const& constantWriter) {
             WriteCustomDirectEventTypeConstant(constantWriter, "onAnimationLoop", "onAnimationLoop");
             WriteCustomDirectEventTypeConstant(constantWriter, "onAnimationFinish", "onAnimationFinish");
         };
+    }
+
+    winrt::Microsoft::ReactNative::ConstantProviderDelegate LottieAnimationViewManager::ExportedCustomDirectEventTypeConstants() noexcept
+    {
+        return nullptr;
     }
 }


### PR DESCRIPTION
fix #1221 