### PR TITLE
fix(web): prevent reset after complete by call stop() manually

### DIFF
--- a/packages/core/src/LottieView/index.web.tsx
+++ b/packages/core/src/LottieView/index.web.tsx
@@ -85,8 +85,6 @@ const LottieView = forwardRef(
 
           case "complete":
             onAnimationFinish?.(false);
-            //prevent reseting animation if not looping, for consistency with native
-            autoPlay && !loop && playerRef.current?.stop();
             break;
 
           case "stop":


### PR DESCRIPTION
In #1196, the `stop` method of inner player was called for preventing reset after animation completion.

This seems to is not required and also occur reset frame to `0`.

[this](https://github.com/dotlottie/player-component/blob/4cb43b6998bada9a1968e9536035d0b6df2d442f/packages/common/src/dotlottie-player.ts#L1563) (`_handleAnimationComplete` handler of dotlottie react player) shows the frame should be in last frame at complete automatically.

Also, `stop` method [implementation](https://github.com/airbnb/lottie-web/blob/0d658b34c40d4e81eafdccbf698815346454a899/player/js/animation/AnimationItem.js#L440) of `lottie-web` resets frame to zero at `stop` method.

