### PR TITLE
chore: update project homepage in package.json

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
     "windows"
   ],
   "author": "Emilio Rodriguez <emiliorodriguez@gmail.com>",
-  "homepage": "https://github.com/airbnb/lottie-react-native#readme",
+  "homepage": "https://airbnb.io/lottie/#/react-native",
   "license": "Apache-2.0",
   "keywords": [
     "lottie",


### PR DESCRIPTION
# Why

Two different links lead to the same place on the npm registry page:

![Screenshot 2024-06-30 113737](https://github.com/lottie-react-native/lottie-react-native/assets/719641/ec9f088f-e969-40da-ab32-0157437d2236)

# How

Update project homepage URL linking to old repository README in `package.json` to point to website highlighted in GitHub repository metadata.