### PR TITLE
Fix incorrect .lottie URI path check

### DIFF
--- a/packages/core/src/LottieView/utils.ts
+++ b/packages/core/src/LottieView/utils.ts
@@ -1,5 +1,15 @@
 import { Image } from 'react-native';
 
+function looksLikeDotLottieURI(uri: string): boolean {
+  try {
+    const parsedURL = new URL(uri);
+    return parsedURL.pathname.endsWith('.lottie');
+  } catch (e) {
+    // Failed to parse URL, assume it's an ordinary JSON
+    return false;
+  }
+}
+
 function parsePossibleSources(source):
   | {
       sourceURL?: string;
@@ -19,8 +29,7 @@ function parsePossibleSources(source):
   }
 
   if (typeof source === 'object' && uri) {
-    // uri contains .lottie extension return sourceDotLottieURI
-    if (uri.includes('.lottie')) {
+    if (looksLikeDotLottieURI(uri)) {
       return { sourceDotLottieURI: uri };
     }
 


### PR DESCRIPTION
The check for whether a URL looks like a `.lottie` file was over-zealous and would trigger if the URL had `.lottie` anywhere in it, regardless of context. Make this more precise by parsing the URL and checking only the extension of the filename part.