### PR TITLE
Revert "Fix incorrect .lottie URI path check"

### DIFF
--- a/packages/core/src/LottieView/utils.ts
+++ b/packages/core/src/LottieView/utils.ts
@@ -1,15 +1,5 @@
 import { Image } from 'react-native';
 
-function looksLikeDotLottieURI(uri: string): boolean {
-  try {
-    const parsedURL = new URL(uri);
-    return parsedURL.pathname.endsWith('.lottie');
-  } catch (e) {
-    // Failed to parse URL, assume it's an ordinary JSON
-    return false;
-  }
-}
-
 function parsePossibleSources(source):
   | {
       sourceURL?: string;
@@ -29,7 +19,8 @@ function parsePossibleSources(source):
   }
 
   if (typeof source === 'object' && uri) {
-    if (looksLikeDotLottieURI(uri)) {
+    // uri contains .lottie extension return sourceDotLottieURI
+    if (uri.includes('.lottie')) {
       return { sourceDotLottieURI: uri };
     }
 


### PR DESCRIPTION
Reverts lottie-react-native/lottie-react-native#1277 as URL is not implemented on Hermes