### PR TITLE
fix CI

### DIFF
--- a/.github/workflows/ios-fabric-build.yml
+++ b/.github/workflows/ios-fabric-build.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        xcode-version: [15.4, 16_Release_Candidate]
+        xcode-version: [15.4, 16]
 
     steps:
       - name: List all available XCode versions

--- a/.github/workflows/ios-paper-build.yml
+++ b/.github/workflows/ios-paper-build.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        xcode-version: [15.4, '16_Release_Candidate']
+        xcode-version: [15.4, 16]
 
     steps:
       - name: List all available XCode versions


### PR DESCRIPTION
Xcode 16 is out, which means the github runner for macOS was updated. Time to fix CI!