### PR TITLE
fix: remove depracated property from AndroidManifest

### DIFF
--- a/packages/core/android/src/main/AndroidManifest.xml
+++ b/packages/core/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.airbnb.android.react.lottie">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
Been a very long time coming. Now that we only support 73 and above, we can safely get rid of this one