### PR TITLE
Fix: Ensure onAnimationFinish Callback Fires Correctly in Fabric

### DIFF
--- a/packages/core/ios/Fabric/LottieAnimationViewComponentView.mm
+++ b/packages/core/ios/Fabric/LottieAnimationViewComponentView.mm
@@ -53,6 +53,18 @@ using namespace facebook::react;
         [_view setResizeMode:RCTNSStringFromString(newLottieProps.resizeMode)];
     }
 
+    if(oldLottieProps.progress != newLottieProps.progress) {
+        [_view setProgress:newLottieProps.progress];
+    }
+
+    if(oldLottieProps.loop != newLottieProps.loop) {
+        [_view setLoop:newLottieProps.loop];
+    }
+
+    if(oldLottieProps.speed != newLottieProps.speed) {
+        [_view setSpeed:newLottieProps.speed];
+    }
+
     if(oldLottieProps.sourceJson != newLottieProps.sourceJson) {
         [_view setSourceJson:RCTNSStringFromString(newLottieProps.sourceJson.c_str())];
     }
@@ -68,19 +80,7 @@ using namespace facebook::react;
     if(oldLottieProps.sourceURL != newLottieProps.sourceURL) {
         [_view setSourceURL:RCTNSStringFromString(newLottieProps.sourceURL)];
     }
-
-    if(oldLottieProps.progress != newLottieProps.progress) {
-        [_view setProgress:newLottieProps.progress];
-    }
-
-    if(oldLottieProps.loop != newLottieProps.loop) {
-        [_view setLoop:newLottieProps.loop];
-    }
-
-    if(oldLottieProps.speed != newLottieProps.speed) {
-        [_view setSpeed:newLottieProps.speed];
-    }
-
+    
     if(oldLottieProps.colorFilters != newLottieProps.colorFilters) {
         [_view setColorFilters:convertColorFilters(newLottieProps.colorFilters)];
     }


### PR DESCRIPTION
Problem
In the Fabric architecture, updateProps calls each property’s setter individually, so the order of setters impacts behavior.

The issue occurs because setSpeed is called after setSourceJson (which initializes LottieAnimationView), affecting the onAnimationFinish callback:

In the new architecture: animationView?.play() is triggered immediately, but without a completion callback.
In the old architecture: playIfNeeded() is used, which includes a completion callback, ensuring onAnimationFinish is fired.
Solution Options
To ensure consistent behavior between the new and old architectures, two potential solutions were considered:

**_Option 1_**: Adjust the order of setter calls so the behaviour will be the same on both archs and make the onAnimationFinish callback in the new architecture.

**_Option 2_**: Provide a completion callback directly in setSpeed, ensuring onAnimationFinish fires reliably. (can be breaking change)
This PR implements Option 1 to maintain consistency in callback behavior across architectures.