### PR TITLE
Depend on lottie-ios ~> 4.5.0 instead of fixed 4.5.0

### DIFF
--- a/packages/core/lottie-react-native.podspec
+++ b/packages/core/lottie-react-native.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
     'Lottie_React_Native_Privacy' => ['ios/PrivacyInfo.xcprivacy'],
   }
 
-  s.dependency 'lottie-ios', '4.5.0'
+  s.dependency 'lottie-ios', '~> 4.5.0'
 
   s.swift_version = '5.9'
 


### PR DESCRIPTION
I have a lottie file that has performance issue with lottie-ios 4.5.0, but that issue is resolved with 4.5.1 
Yet, for now I can't depend on lottie-ios 4.5.1 because lottie-react-native is depending on lottie-ios 4.5.0 fixed version.


If it's not intended, as [cocoapods guide recommends ](https://guides.cocoapods.org/syntax/podspec.html#dependency), I think it's good idea to allow minor version updates in lottie-ios 