### PR TITLE
Build Error with React Native 0.80 - Kotlin Type Mismatch

### DIFF
--- a/packages/core/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.kt
+++ b/packages/core/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.kt
@@ -247,7 +247,7 @@ class LottieAnimationViewPropertyManager(view: LottieAnimationView) {
         view: LottieAnimationView
     ) {
         val color: Int = if (colorFilter.getType("color") == ReadableType.Map) {
-            ColorPropConverter.getColor(colorFilter.getMap("color"), view.context)
+            ColorPropConverter.getColor(colorFilter.getMap("color"), view.context) ?: 0
         } else {
             colorFilter.getInt("color")
         }


### PR DESCRIPTION
When building a React Native 0.80 project with lottie-react-native version 7.2.2, the build fails with the following Kotlin compilation errors:

> > Task :lottie-react-native:compileDebugKotlin FAILED
> 
> e: file:///path/to/node_modules/lottie-react-native/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewPropertyManager.kt:249:26 
> Initializer type mismatch: expected 'Int', actual 'Int?'.
> 
> e: file:///path/to/node_modules/lottie-react-native/android/src/main/java/com/airbnb/android/reaThis pull request includes a small change to the `LottieAnimationViewPropertyManager` class in the `LottieAnimationViewPropertyManager.kt` file. The change ensures that the `getColor` method returns a default value of `0` if the result is null.
> [Copilot is generating a summary...]ct/lottie/LottieAnimationViewPropertyManager.kt:250:13 
> Type mismatch: inferred type is 'Int?', but 'Int' was expected.


Solution: The key change is adding ?: 0 to provide a default value (transparent) when the color conversion returns null.