### PR TITLE
fix: fix ios new arch by declaring component for codegen

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -97,6 +97,11 @@
     "android": {
       "javaPackageName": "com.airbnb.android.react.lottie"
     },
+    "ios": {
+      "componentProvider": {
+        "LottieAnimationView": "LottieAnimationViewComponentView"
+      }
+    },
     "name": "lottiereactnative",
     "type": "components",
     "jsSrcsDir": "./src/specs"


### PR DESCRIPTION
## Summary

closes #1356 

On ios on the new architecture, methods invoked on the view are being handled by the old arch manager. In order for the fabric files to be picked up correctly, the component provider needs to be defined in the codegen config in package.json.

Tested to work on both new and old arch
