### PR TITLE
fix(ios): wrong animation when switching between raw json and string source in fabric

### DIFF
--- a/packages/core/ios/LottieReactNative/ContainerView.swift
+++ b/packages/core/ios/LottieReactNative/ContainerView.swift
@@ -17,9 +17,7 @@ class ContainerView: RCTView {
     private var progress: CGFloat = 0.0
     private var autoPlay: Bool = false
     private var loop: LottieLoopMode = .playOnce
-    private var sourceJson: String = ""
     private var resizeMode: String = ""
-    private var sourceName: String = ""
     private var colorFilters: [NSDictionary] = []
     private var textFilters: [NSDictionary] = []
     private var renderMode: RenderingEngineOption = .automatic
@@ -206,9 +204,7 @@ class ContainerView: RCTView {
             return
         }
 
-        sourceJson = newSourceJson
-
-        guard let data = sourceJson.data(using: String.Encoding.utf8),
+        guard let data = newSourceJson.data(using: String.Encoding.utf8),
               let animation = try? JSONDecoder().decode(LottieAnimation.self, from: data) else {
             failureCallback("Unable to create the lottie animation object from the JSON source")
             return
@@ -227,14 +223,8 @@ class ContainerView: RCTView {
             return
         }
 
-        if newSourceName == sourceName {
-            return
-        }
-
-        sourceName = newSourceName
-
         let nextAnimationView = LottieAnimationView(
-            name: sourceName,
+            name: newSourceName,
             configuration: lottieConfiguration
         )
 


### PR DESCRIPTION
Fixes an issue where a lottie view switching between a raw json (imported on the JS side) and a local asset (added to the iOS project) leads to the wrong animation being presented. The issue is only happening in the new architecture and on iOS only.

Upon inspection, when updateProps() is called, the local properties `sourceJson` and `sourceName` will not be updated properly and therefore when switching between the two formats, the old value in "sourceName" will still be set when a json animation is presented. When switching back, the check `newSourceName == sourceName` will equal to true and therefore the new animation won't be presented as it should.

The local properties don't seem to be used anywhere and can just create confusion/incorrect state when switching between different sources. To mitigate this issue, the properties have been removed which means that whenever the source changes, the animation will be changed as well as long as the string is valid. In the old architecture, the properties are always reset when the animation changes and therefore the issue isn't present there.

Tested on both the reproducer app and a custom app running the new architecture [here](https://github.com/ismarbesic/lottie-react-native-bug-repro).

Fixes #1358.