### PR TITLE
feat: add container style property

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -176,6 +176,7 @@ const App: React.FC = () => {
               autoPlay={false}
               loop={isLooping}
               speed={animationSpeed}
+              containerStyle={styles.lottieContainer}
               style={styles.lottie}
               resizeMode="contain"
               colorFilters={colorFilters}
@@ -315,9 +316,9 @@ const styles = StyleSheet.create({
   lottie: {
     width: Math.min(screenWidth - 64, 320),
     height: Math.min(screenWidth - 64, 320),
-    borderRadius: 16,
-    backgroundColor: colors.background,
+    borderRadius: 60,
   },
+  lottieContainer: { backgroundColor: "gray", borderRadius: 60 },
   loadingOverlay: {
     position: "absolute",
     top: 0,

--- a/packages/core/src/LottieView/index.tsx
+++ b/packages/core/src/LottieView/index.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { NativeSyntheticEvent, ViewProps, processColor } from 'react-native';
+import {
+  NativeSyntheticEvent,
+  View,
+  ViewStyle,
+  processColor,
+} from 'react-native';
 
 import { parsePossibleSources } from './utils';
 
@@ -9,7 +14,7 @@ import NativeLottieAnimationView, {
   Commands,
 } from '../specs/LottieAnimationViewNativeComponent';
 
-type Props = LottieViewProps & { containerProps?: ViewProps };
+type Props = LottieViewProps & { containerStyle?: ViewStyle };
 
 const defaultProps: Props = {
   source: undefined,
@@ -81,8 +86,8 @@ export class LottieView extends React.PureComponent<Props, {}> {
   };
 
   private onAnimationLoaded = () => {
-    this.props.onAnimationLoaded?.()
-  }
+    this.props.onAnimationLoaded?.();
+  };
 
   private captureRef(ref: React.ElementRef<typeof NativeLottieAnimationView>) {
     if (ref === null) {
@@ -104,11 +109,15 @@ export class LottieView extends React.PureComponent<Props, {}> {
       textFiltersAndroid,
       textFiltersIOS,
       resizeMode,
+      containerStyle,
       ...rest
     } = this.props;
 
     if (source == null) {
-      console.warn('LottieView needs `source` parameter, provided value for source:', source);
+      console.warn(
+        'LottieView needs `source` parameter, provided value for source:',
+        source,
+      );
       return null;
     }
 
@@ -117,8 +126,8 @@ export class LottieView extends React.PureComponent<Props, {}> {
     const speed =
       duration && sources.sourceJson && (source as any).fr
         ? Math.round(
-          (((source as any).op / (source as any).fr) * 1000) / duration,
-        )
+            (((source as any).op / (source as any).fr) * 1000) / duration,
+          )
         : this.props.speed;
 
     const colorFilters = this.props.colorFilters?.map((colorFilter) => ({
@@ -127,21 +136,23 @@ export class LottieView extends React.PureComponent<Props, {}> {
     }));
 
     return (
-      <NativeLottieAnimationView
-        ref={this.captureRef}
-        {...rest}
-        colorFilters={colorFilters}
-        textFiltersAndroid={textFiltersAndroid}
-        textFiltersIOS={textFiltersIOS}
-        speed={speed}
-        style={style}
-        onAnimationFinish={this.onAnimationFinish}
-        onAnimationFailure={this.onAnimationFailure}
-        onAnimationLoaded={this.onAnimationLoaded}
-        autoPlay={autoPlay}
-        resizeMode={resizeMode}
-        {...sources}
-      />
+      <View style={containerStyle} collapsable={false}>
+        <NativeLottieAnimationView
+          ref={this.captureRef}
+          {...rest}
+          colorFilters={colorFilters}
+          textFiltersAndroid={textFiltersAndroid}
+          textFiltersIOS={textFiltersIOS}
+          speed={speed}
+          style={style}
+          onAnimationFinish={this.onAnimationFinish}
+          onAnimationFailure={this.onAnimationFailure}
+          onAnimationLoaded={this.onAnimationLoaded}
+          autoPlay={autoPlay}
+          resizeMode={resizeMode}
+          {...sources}
+        />
+      </View>
     );
   }
 }


### PR DESCRIPTION
This PR fixes #1363

You can now change the style of the lottie container using `containerStyle` property. Lottie itself does not support all style properties such as border radius on Android. I will be investigating this later on to see what the issue is on Android.