### PR TITLE
fix: support static animation sources

### DIFF
--- a/example/type-tests/source.tsx
+++ b/example/type-tests/source.tsx
@@ -1,4 +1,0 @@
-import React from "react";
-import LottieView from "lottie-react-native";
-
-export const staticAnimationSource = <LottieView source={1} />;

--- a/example/type-tests/source.tsx
+++ b/example/type-tests/source.tsx
@@ -1,0 +1,4 @@
+import React from "react";
+import LottieView from "lottie-react-native";
+
+export const staticAnimationSource = <LottieView source={1} />;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -43,7 +43,7 @@ export interface LottieViewProps {
    * animation, obtained (for example) with something like
    * `require('../path/to/animation.json')`
    */
-  source: string | AnimationObject | { uri: string };
+  source: string | AnimationObject | { uri: string } | number;
 
   /**
    * A number between 0 and 1, or an `Animated` number between 0 and 1. This number

--- a/packages/nitro/src/types.ts
+++ b/packages/nitro/src/types.ts
@@ -43,7 +43,7 @@ export interface LottieViewProps {
    * animation, obtained (for example) with something like
    * `require('../path/to/animation.json')`
    */
-  source: string | AnimationObject | { uri: string };
+  source: string | AnimationObject | { uri: string } | number;
 
   /**
    * A number between 0 and 1, or an `Animated` number between 0 and 1. This number


### PR DESCRIPTION
## Summary

- allow React Native numeric static asset references in the v7 `source` prop type
- keep the v8/Nitro public type byte-aligned with v7
- add a consumer type test using `<LottieView source={1} />`

The runtime already handles numeric sources through `Image.resolveAssetSource`; this aligns the public type with that existing path. This follows the correction proposed in the now-closed #1401 and adds v8 parity plus CI-backed coverage.

## Verification

- `yarn setup`
- `yarn tsc` (includes the new consumer type test)
- `yarn nitro:tsc:lib`
- `yarn nitro:tsc`
- Prettier check for the new type test
- verified `packages/core/src/types.ts` and `packages/nitro/src/types.ts` remain byte-identical
- `git diff --check`

Closes #1403.