### PR TITLE
fix: dotLottie detection matches '.lottie' substring anywhere in URI

### DIFF
--- a/packages/core/src/LottieView/utils.ts
+++ b/packages/core/src/LottieView/utils.ts
@@ -19,8 +19,8 @@ function parsePossibleSources(source):
   }
 
   if (typeof source === 'object' && uri) {
-    // uri contains .lottie extension return sourceDotLottieURI
-    if (uri.includes('.lottie')) {
+    // uri ends with .lottie extension return sourceDotLottieURI
+    if (uri.split(/[?#]/)[0].endsWith('.lottie')) {
       return { sourceDotLottieURI: uri };
     }
 

--- a/packages/nitro/src/LottieView/utils.ts
+++ b/packages/nitro/src/LottieView/utils.ts
@@ -19,8 +19,8 @@ function parsePossibleSources(source: any):
   }
 
   if (typeof source === 'object' && uri) {
-    // uri contains .lottie extension return sourceDotLottieURI
-    if (uri.includes('.lottie')) {
+    // uri ends with .lottie extension return sourceDotLottieURI
+    if (uri.split(/[?#]/)[0].endsWith('.lottie')) {
       return { sourceDotLottieURI: uri };
     }
 


### PR DESCRIPTION
Bug: parsePossibleSources uses uri.includes('.lottie') to detect dotLottie archives. Any URL whose host contains .lottie — e.g. https://cdn.lottielab.com/l/xxx.json is misrouted to sourceDotLottieURI. Native then tries to unzip plain JSON as a dotLottie archive, fails silently, and nothing renders on iOS or Android.

Fix: check the actual file extension, ignoring query: uri.split(/[?#]/)[0].endsWith('.lottie').

Repro: <LottieView source={{ uri: 'https://cdn.lottielab.com/l/xxx.json }} autoPlay /> — blank view before, plays after.


Fixes [#1331](https://github.com/lottie-react-native/lottie-react-native/issues/1331)